### PR TITLE
Use ArrayRef type to implement efficient array format

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -40,7 +40,7 @@ fn main() -> Result<(), String> {
             println!("Match: {:?}", result.1);
         }
 
-        if args.compile {
+        if args.compile || args.compile_and_run {
             let mut bytecode =
                 compile(&result.1).map_err(|e| format!("Error in compile(): {:?}", e))?;
             // println!("bytecode: {:#?}", bytecode);

--- a/parser/src/compiler.rs
+++ b/parser/src/compiler.rs
@@ -556,7 +556,7 @@ fn emit_expr(expr: &Expression, compiler: &mut Compiler) -> Result<usize, String
                     .iter()
                     .map(|v| {
                         if let RunResult::Yield(y) = eval(v, &mut ctx)? {
-                            Ok(Rc::new(RefCell::new(y)))
+                            Ok(y)
                         } else {
                             Err("Break in array literal not supported".to_string())
                         }

--- a/parser/src/interpreter.rs
+++ b/parser/src/interpreter.rs
@@ -44,6 +44,12 @@ pub(crate) fn binary_op_str(
         // "Deref" the references before binary
         (Value::Ref(lhs), ref rhs) => binary_op_str(&lhs.borrow(), rhs, d, i, s)?,
         (ref lhs, Value::Ref(rhs)) => binary_op_str(lhs, &rhs.borrow(), d, i, s)?,
+        (Value::ArrayRef(lhs, idx), ref rhs) => {
+            binary_op_str(&lhs.borrow().values.get(*idx).unwrap(), rhs, d, i, s)?
+        }
+        (ref lhs, Value::ArrayRef(rhs, idx)) => {
+            binary_op_str(lhs, &rhs.borrow().values.get(*idx).unwrap(), d, i, s)?
+        }
         (Value::F64(lhs), rhs) => Value::F64(d(*lhs, coerce_f64(&rhs)?)),
         (lhs, Value::F64(rhs)) => Value::F64(d(coerce_f64(&lhs)?, *rhs)),
         (Value::F32(lhs), rhs) => Value::F32(d(*lhs as f64, coerce_f64(&rhs)?) as f32),

--- a/parser/src/interpreter/test.rs
+++ b/parser/src/interpreter/test.rs
@@ -457,11 +457,11 @@ fn array_literal_test() {
 #[test]
 fn array_literal_eval_test() {
     use Value::*;
-    fn i64(i: i64) -> Rc<RefCell<Value>> {
-        Rc::new(RefCell::new(I64(i)))
+    fn i64(i: i64) -> Value {
+        I64(i)
     }
-    fn f64(i: f64) -> Rc<RefCell<Value>> {
-        Rc::new(RefCell::new(F64(i)))
+    fn f64(i: f64) -> Value {
+        F64(i)
     }
     assert_eq!(
         eval0(&full_expression("[1,3,5]").unwrap().1),
@@ -536,13 +536,13 @@ fn array_index_eval_test() {
     // Very ugly idiom to extract a clone of a variant in a RefCell
     std::cell::Ref::map(a_ref.borrow(), |v| match v {
         Value::Array(a) => {
-            a_rc = Some(a.borrow().values[1].clone());
+            a_rc = Some(Value::ArrayRef(a.clone(), 1));
             &()
         }
         _ => panic!("a must be an array"),
     });
 
-    assert_eq!(run_result, Ok(RunResult::Yield(Value::Ref(a_rc.unwrap()))));
+    assert_eq!(run_result, Ok(RunResult::Yield(a_rc.unwrap())));
 
     // Technically, this test will return a reference to an element in a temporary array,
     // but we wouldn't care and just unwrap_deref.

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -12,7 +12,6 @@ use nom::{
 use std::{
     cell::RefCell,
     io::{Read, Write},
-    ops::Deref,
     rc::Rc,
     string::FromUtf8Error,
 };
@@ -331,10 +330,10 @@ impl Value {
 
     /// Recursively peels off references
     pub fn deref(self) -> Self {
-        if let Value::Ref(r) = self {
-            r.borrow().clone().deref()
-        } else {
-            self
+        match self {
+            Value::Ref(r) => r.borrow().clone().deref(),
+            Value::ArrayRef(r, idx) => (*r.borrow()).values.get(idx).cloned().unwrap(),
+            _ => self,
         }
     }
 }

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -292,6 +292,19 @@ impl Value {
                     ));
                 }
             }
+            Value::ArrayRef(rc, idx2) => {
+                let array_int = rc.borrow();
+                array_int
+                    .values
+                    .get(*idx2)
+                    .ok_or_else(|| {
+                        format!(
+                            "array index out of range: {idx2} is larger than array length {}",
+                            array_int.values.len()
+                        )
+                    })?
+                    .array_get_ref(idx)?
+            }
             _ => return Err("array index must be called for an array".to_string()),
         })
     }

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -12,6 +12,7 @@ use nom::{
 use std::{
     cell::RefCell,
     io::{Read, Write},
+    ops::Deref,
     rc::Rc,
     string::FromUtf8Error,
 };
@@ -74,15 +75,15 @@ impl TypeDecl {
 #[derive(Debug, PartialEq, Clone)]
 pub struct ArrayInt {
     pub(crate) type_decl: TypeDecl,
-    pub(crate) values: Vec<Rc<RefCell<Value>>>,
+    pub(crate) values: Vec<Value>,
 }
 
 impl ArrayInt {
-    pub(crate) fn new(type_decl: TypeDecl, values: Vec<Rc<RefCell<Value>>>) -> Rc<RefCell<Self>> {
+    pub(crate) fn new(type_decl: TypeDecl, values: Vec<Value>) -> Rc<RefCell<Self>> {
         Rc::new(RefCell::new(Self { type_decl, values }))
     }
 
-    pub fn values(&self) -> &[Rc<RefCell<Value>>] {
+    pub fn values(&self) -> &[Value] {
         &self.values
     }
 }
@@ -96,6 +97,7 @@ pub enum Value {
     Str(String),
     Array(Rc<RefCell<ArrayInt>>),
     Ref(Rc<RefCell<Value>>),
+    ArrayRef(Rc<RefCell<ArrayInt>>, usize),
 }
 
 impl Default for Value {
@@ -151,13 +153,20 @@ impl ToString for Value {
                 "[{}]",
                 &v.borrow().values.iter().fold("".to_string(), |acc, cur| {
                     if acc.is_empty() {
-                        cur.borrow().to_string()
+                        cur.to_string()
                     } else {
-                        acc + ", " + &cur.borrow().to_string()
+                        acc + ", " + &cur.to_string()
                     }
                 })
             ),
             Self::Ref(v) => "&".to_string() + &v.borrow().to_string(),
+            Self::ArrayRef(v, idx) => {
+                if let Some(v) = (*v.borrow()).values.get(*idx) {
+                    v.to_string()
+                } else {
+                    "Array index out of range".to_string()
+                }
+            }
         }
     }
 }
@@ -192,7 +201,7 @@ impl Value {
                 writer.write_all(&values.len().to_le_bytes())?;
                 decl.serialize(writer)?;
                 for value in values {
-                    value.borrow().serialize(writer)?;
+                    value.serialize(writer)?;
                 }
                 Ok(())
             }
@@ -200,6 +209,18 @@ impl Value {
                 writer.write_all(&REF_TAG.to_le_bytes())?;
                 val.borrow().serialize(writer)?;
                 Ok(())
+            }
+            Self::ArrayRef(val, idx) => {
+                if let Some(v) = (*val.borrow()).values.get(*idx) {
+                    writer.write_all(&REF_TAG.to_le_bytes())?;
+                    v.serialize(writer)?;
+                    Ok(())
+                } else {
+                    Err(std::io::Error::new(
+                        std::io::ErrorKind::Other,
+                        "ArrayRef out of range".to_string(),
+                    ))
+                }
             }
         }
     }
@@ -231,7 +252,7 @@ impl Value {
                 let value_count = parse!(usize);
                 let decl = TypeDecl::deserialize(reader)?;
                 let values = (0..value_count)
-                    .map(|_| Value::deserialize(reader).map(RefCell::new).map(Rc::new))
+                    .map(|_| Value::deserialize(reader))
                     .collect::<Result<_, _>>()?;
                 Self::Array(ArrayInt::new(decl, values))
             }
@@ -243,7 +264,7 @@ impl Value {
     /// array index will return a reference.
     fn _array_assign(&mut self, idx: usize, value: Value) {
         if let Value::Array(array) = self {
-            array.borrow_mut().values[idx] = Rc::new(RefCell::new(value.deref()));
+            array.borrow_mut().values[idx] = value.deref();
         } else {
             panic!("assign_array must be called for an array")
         }
@@ -252,7 +273,7 @@ impl Value {
     fn _array_get(&self, idx: u64) -> Value {
         match self {
             Value::Ref(rc) => rc.borrow()._array_get(idx),
-            Value::Array(array) => array.borrow_mut().values[idx as usize].borrow().clone(),
+            Value::Array(array) => array.borrow_mut().values[idx as usize].clone(),
             _ => panic!("array index must be called for an array"),
         }
     }
@@ -260,12 +281,17 @@ impl Value {
     pub fn array_get_ref(&self, idx: u64) -> Result<Value, EvalError> {
         Ok(match self {
             Value::Ref(rc) => rc.borrow().array_get_ref(idx)?,
-            Value::Array(array) => Value::Ref({
-                let array = array.borrow();
-                array.values.get(idx as usize)
-                    .ok_or_else(|| format!("array index out of range: {idx} is larger than array length {}", array.values.len()))?
-                    .clone()
-            }),
+            Value::Array(array) => {
+                let array_int = array.borrow();
+                if (idx as usize) < array_int.values.len() {
+                    Value::ArrayRef(array.clone(), idx as usize)
+                } else {
+                    return Err(format!(
+                        "array index out of range: {idx} is larger than array length {}",
+                        array_int.values.len()
+                    ));
+                }
+            }
             _ => return Err("array index must be called for an array".to_string()),
         })
     }
@@ -274,10 +300,7 @@ impl Value {
         match self {
             Value::Ref(r) => r.borrow_mut().array_push(value),
             Value::Array(array) => {
-                array
-                    .borrow_mut()
-                    .values
-                    .push(Rc::new(RefCell::new(value.deref())));
+                array.borrow_mut().values.push(value.deref());
                 Ok(())
             }
             _ => Err("push() must be called for an array".to_string()),

--- a/parser/src/vm.rs
+++ b/parser/src/vm.rs
@@ -121,13 +121,16 @@ fn interpret_fn(
                 }
                 let val = match vm.get(inst.arg0) {
                     Value::Ref(aref) => (*aref.borrow()).clone(),
+                    Value::ArrayRef(aref, idx) => (*aref.borrow()).values[*idx].clone(),
                     v => v.clone(),
                 };
                 let target = vm.get_mut(inst.arg1);
-                if let Value::Ref(vref) = target {
-                    vref.replace(val);
-                } else {
-                    vm.set(inst.arg1, val);
+                match target {
+                    Value::Ref(vref) => {
+                        vref.replace(val);
+                    }
+                    Value::ArrayRef(vref, idx) => vref.borrow_mut().values[*idx] = val,
+                    _ => vm.set(inst.arg1, val),
                 }
             }
             OpCode::Incr => {
@@ -139,7 +142,12 @@ fn interpret_fn(
                         Value::F64(i) => *i += 1.,
                         Value::F32(i) => *i += 1.,
                         Value::Ref(r) => incr(&mut r.borrow_mut())?,
-                        _ => return Err(format!("Attempt to increment non-numerical value {:?}", val)),
+                        _ => {
+                            return Err(format!(
+                                "Attempt to increment non-numerical value {:?}",
+                                val
+                            ))
+                        }
                     }
                     Ok(())
                 }

--- a/parser/src/vm.rs
+++ b/parser/src/vm.rs
@@ -212,9 +212,21 @@ fn interpret_fn(
             }
             OpCode::Deref => {
                 let target = vm.get_mut(inst.arg0);
-                if let Value::Ref(v) = target {
-                    let cloned = v.borrow().clone();
-                    *target = cloned;
+                match target {
+                    Value::Ref(v) => {
+                        let cloned = v.borrow().clone();
+                        *target = cloned;
+                    }
+                    Value::ArrayRef(a, idx) => {
+                        let cloned = a
+                            .borrow()
+                            .values
+                            .get(*idx)
+                            .ok_or_else(|| "Deref instruction failed with ArrayRef out of bounds")?
+                            .clone();
+                        *target = cloned;
+                    }
+                    _ => (),
                 }
             }
             OpCode::Lt => {

--- a/parser/src/vm/test.rs
+++ b/parser/src/vm/test.rs
@@ -225,10 +225,7 @@ fn array_init() {
     let res = compile_and_run_with("var a: [i32] = [1 + 3]; print(a); ", |vals| {
         assert_eq!(
             vals[0],
-            Value::Array(ArrayInt::new(
-                TypeDecl::Any,
-                vec![Rc::new(RefCell::new(Value::I64(4)))]
-            ))
+            Value::Array(ArrayInt::new(TypeDecl::Any, vec![Value::I64(4)]))
         )
     });
     assert!(res.is_ok());
@@ -255,10 +252,7 @@ print(a);"#,
         |vals| {
             assert_eq!(
                 vals[0],
-                Value::Array(ArrayInt::new(
-                    TypeDecl::Any,
-                    vec![Rc::new(RefCell::new(Value::I64(10)))]
-                ))
+                Value::Array(ArrayInt::new(TypeDecl::Any, vec![Value::I64(10)]))
             )
         },
     );

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -31,7 +31,7 @@ fn s_print(vals: &[Value]) -> Result<Value, EvalError> {
                         &val.borrow()
                             .values()
                             .iter()
-                            .map(|v| v.borrow().clone())
+                            .map(|v| v.clone())
                             .collect::<Vec<_>>(),
                     );
                     wasm_print("]");
@@ -39,6 +39,15 @@ fn s_print(vals: &[Value]) -> Result<Value, EvalError> {
                 Value::Ref(r) => {
                     wasm_print("ref(");
                     print_inner(&[r.borrow().clone()]);
+                    wasm_print(")");
+                }
+                Value::ArrayRef(r, idx) => {
+                    wasm_print("aref(");
+                    if let Some(val) = r.borrow().values().get(*idx) {
+                        print_inner(&[val.clone()]);
+                    } else {
+                        wasm_print("?");
+                    }
                     wasm_print(")");
                 }
             }
@@ -62,10 +71,15 @@ fn s_puts(vals: &[Value]) -> Result<Value, EvalError> {
                     &val.borrow()
                         .values()
                         .iter()
-                        .map(|v| v.borrow().clone())
+                        .map(|v| v.clone())
                         .collect::<Vec<_>>(),
                 ),
                 Value::Ref(r) => puts_inner(&[r.borrow().clone()]),
+                Value::ArrayRef(r, idx) => {
+                    if let Some(val) = r.borrow().values().get(*idx) {
+                        puts_inner(&[val.clone()]);
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
We have an issue with performance in array internal representation.
See [the Wiki](https://github.com/msakuta/rusty-parser/wiki/Array-Internal-Representation) for details.

This PR will fix the issue by introducing `ArrayRef` type and make `ArrayInt` a flat `Vec<Value>`.

Also fixes #11 