### PR TITLE
Support default arguments in function definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,11 @@ If you have a pre-compiled bytecode file, you can just run it without compiling 
 You can also build a wasm package and run the interpreter on the browser.
 
     cd wasm
-    wasm-pack build --target web
+    npm run build
 
 To launch the application, you can use `npx`
 
+    cd dist
     npx serve
 
 and browse http://localhost:5000.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ In ascending order of difficulty.
 * [x] Function return types
 * [x] Static type checking (instead of runtime coercion)
 * [x] Type cast operator `as`
+* [x] Line and block comments (`/*`, `*/`, `//`)
 * [x] [Named arguments in function calls](https://github.com/msakuta/rusty-parser/wiki/Function-signature#named-argument-in-function-call)
 * [ ] [Default argument](https://github.com/msakuta/rusty-parser/wiki/Function-signature#default-argument)
 * [ ] Type casting in bytecode

--- a/parser/src/compiler.rs
+++ b/parser/src/compiler.rs
@@ -574,7 +574,7 @@ fn retrieve_fn_signatures(stmts: &[Statement], env: &mut CompilerEnv) -> Result<
             Statement::FnDecl {
                 name, args, stmts, ..
             } => {
-                let args = args.iter().map(|arg| arg.0.to_string()).collect();
+                let args = args.iter().map(|arg| arg.name.to_string()).collect();
                 let bytecode = FnBytecode::proto(args);
                 env.functions
                     .insert(name.to_string(), FnProto::Code(bytecode));
@@ -619,7 +619,7 @@ fn emit_stmts(stmts: &[Statement], compiler: &mut Compiler) -> Result<Option<usi
                         // The 0th index is used for function name / return value, so the args start with 1.
                         let target = idx + 1;
                         let local = LocalVar {
-                            name: arg.0.to_owned(),
+                            name: arg.name.to_owned(),
                             stack_idx: target,
                         };
                         compiler.target_stack.push(Target::Local(target));

--- a/parser/src/compiler.rs
+++ b/parser/src/compiler.rs
@@ -166,6 +166,16 @@ fn read_str(reader: &mut impl Read) -> Result<String, ReadError> {
     Ok(String::from_utf8(buf)?)
 }
 
+fn write_bool(b: bool, writer: &mut impl Write) -> std::io::Result<()> {
+    writer.write_all(&[if b { 1u8 } else { 0u8 }])
+}
+
+fn read_bool(reader: &mut impl Read) -> Result<bool, ReadError> {
+    let mut buf = [0u8; 1];
+    reader.read_exact(&mut buf)?;
+    Ok(buf[0] != 0)
+}
+
 pub type NativeFn = Box<dyn Fn(&[Value]) -> Result<Value, EvalError>>;
 
 pub(crate) enum FnProto {
@@ -174,7 +184,7 @@ pub(crate) enum FnProto {
 }
 
 impl FnProto {
-    pub fn args(&self) -> &[String] {
+    pub fn args(&self) -> &[BytecodeArg] {
         match self {
             Self::Code(bytecode) => &bytecode.args,
             _ => &[],
@@ -259,9 +269,15 @@ pub fn std_functions(
 }
 
 #[derive(Debug, Clone)]
+pub struct BytecodeArg {
+    name: String,
+    init: Option<Value>,
+}
+
+#[derive(Debug, Clone)]
 pub struct FnBytecode {
     pub(crate) literals: Vec<Value>,
-    pub(crate) args: Vec<String>,
+    pub(crate) args: Vec<BytecodeArg>,
     pub(crate) instructions: Vec<Instruction>,
     pub(crate) stack_size: usize,
 }
@@ -271,7 +287,13 @@ impl FnBytecode {
     fn proto(args: Vec<String>) -> Self {
         Self {
             literals: vec![],
-            args,
+            args: args
+                .into_iter()
+                .map(|arg| BytecodeArg {
+                    name: arg,
+                    init: None,
+                })
+                .collect(),
             instructions: vec![],
             stack_size: 0,
         }
@@ -290,8 +312,12 @@ impl FnBytecode {
             literal.serialize(writer)?;
         }
         writer.write_all(&self.args.len().to_le_bytes())?;
-        for literal in &self.args {
-            write_str(literal, writer)?;
+        for arg in &self.args {
+            write_str(&arg.name, writer)?;
+            write_bool(arg.init.is_some(), writer)?;
+            if let Some(ref init) = arg.init {
+                init.serialize(writer)?;
+            }
         }
         writer.write_all(&self.instructions.len().to_le_bytes())?;
         for inst in &self.instructions {
@@ -313,9 +339,17 @@ impl FnBytecode {
 
         let mut args = [0u8; std::mem::size_of::<usize>()];
         reader.read_exact(&mut args)?;
-        let args = usize::from_le_bytes(args);
-        let args = (0..args)
-            .map(|_| read_str(reader))
+        let num_args = usize::from_le_bytes(args);
+        let args = (0..num_args)
+            .map(|_| -> Result<_, ReadError> {
+                let name = read_str(reader)?;
+                let init = if read_bool(reader)? {
+                    Some(Value::deserialize(reader)?)
+                } else {
+                    None
+                };
+                Ok(BytecodeArg { name, init })
+            })
             .collect::<Result<Vec<_>, _>>()?;
 
         let mut instructions = [0u8; std::mem::size_of::<usize>()];
@@ -340,7 +374,7 @@ impl FnBytecode {
         }
         writeln!(f, "Args({}):", self.args.len())?;
         for (i, arg) in self.args.iter().enumerate() {
-            writeln!(f, "  [{}] {}", i, arg)?;
+            writeln!(f, "  [{}] {} = {:?}", i, arg.name, arg.init)?;
         }
         writeln!(f, "Instructions({}):", self.instructions.len())?;
         for (i, inst) in self.instructions.iter().enumerate() {
@@ -408,12 +442,12 @@ struct Compiler<'a> {
 }
 
 impl<'a> Compiler<'a> {
-    fn new(args: Vec<LocalVar>, env: &'a mut CompilerEnv) -> Self {
+    fn new(args: Vec<LocalVar>, fn_args: Vec<BytecodeArg>, env: &'a mut CompilerEnv) -> Self {
         Self {
             env,
             bytecode: FnBytecode {
                 literals: vec![],
-                args: args.iter().map(|arg| arg.name.to_owned()).collect(),
+                args: fn_args,
                 instructions: vec![],
                 stack_size: 0,
             },
@@ -512,7 +546,7 @@ fn compile_int<'src, 'ast>(
 
     retrieve_fn_signatures(stmts, &mut env)?;
 
-    let mut compiler = Compiler::new(vec![], &mut env);
+    let mut compiler = Compiler::new(vec![], vec![], &mut env);
     if let Some(last_target) = emit_stmts(stmts, &mut compiler)? {
         compiler
             .bytecode
@@ -555,8 +589,9 @@ fn compile_fn<'src, 'ast>(
     env: &mut CompilerEnv,
     stmts: &'ast [Statement<'src>],
     args: Vec<LocalVar>,
+    fn_args: Vec<BytecodeArg>,
 ) -> Result<FnProto, String> {
-    let mut compiler = Compiler::new(args, env);
+    let mut compiler = Compiler::new(args, fn_args, env);
     if let Some(last_target) = emit_stmts(stmts, &mut compiler)? {
         compiler
             .bytecode
@@ -611,8 +646,8 @@ fn emit_stmts(stmts: &[Statement], compiler: &mut Compiler) -> Result<Option<usi
             Statement::FnDecl {
                 name, args, stmts, ..
             } => {
-                dbg_println!("Args: {:?}", args);
-                let args = args
+                dbg_println!("FnDecl: Args: {:?}", args);
+                let a_args = args
                     .iter()
                     .enumerate()
                     .map(|(idx, arg)| {
@@ -626,8 +661,32 @@ fn emit_stmts(stmts: &[Statement], compiler: &mut Compiler) -> Result<Option<usi
                         local
                     })
                     .collect();
-                dbg_println!("Locals: {:?}", args);
-                let fun = compile_fn(&mut compiler.env, stmts, args)?;
+                let fn_args = args
+                    .iter()
+                    .map(|arg| {
+                        let init = if let Some(ref init) = arg.init {
+                            // Run the interpreter to fold the constant expression into a value.
+                            // Note that the interpreter has an empty context, so it cannot access any
+                            // global variables or user defined functions.
+                            match eval(init, &mut EvalContext::new())? {
+                                RunResult::Yield(val) => Some(val),
+                                _ => {
+                                    return Err(
+                                        "Function default arg should not suspend".to_string()
+                                    )
+                                }
+                            }
+                        } else {
+                            None
+                        };
+                        Ok(BytecodeArg {
+                            name: arg.name.to_owned(),
+                            init,
+                        })
+                    })
+                    .collect::<Result<_, _>>()?;
+                dbg_println!("FnDecl actual args: {:?} fn_args: {:?}", a_args, fn_args);
+                let fun = compile_fn(&mut compiler.env, stmts, a_args, fn_args)?;
                 compiler.env.functions.insert(name.to_string(), fun);
             }
             Statement::Expression(ref ex) => {
@@ -760,14 +819,38 @@ fn emit_expr(expr: &Expression, compiler: &mut Compiler) -> Result<usize, String
             Ok(lhs_result)
         }
         ExprEnum::FnInvoke(fname, argss) => {
+            let default_args = {
+                let Some(fun) = compiler.env.functions.get(*fname) else {
+                    return Err(format!("Function {fname} is not defined"));
+                };
+
+                let fn_args = fun.args();
+
+                if argss.len() <= fn_args.len() {
+                    let fn_args = fn_args[argss.len()..].to_vec();
+
+                    fn_args
+                        .into_iter()
+                        .filter_map(|arg| arg.init.as_ref().map(|init| init.clone()))
+                        .collect()
+                } else {
+                    vec![]
+                }
+            };
+
             // Function arguments have value semantics, even if it was an array element.
             // Unless we emit `Deref` here, we might leave a reference in the stack that can be
             // accidentally overwritten. I'm not sure this is the best way to avoid it.
-            let unnamed_args = argss
+            let mut unnamed_args = argss
                 .iter()
                 .filter(|v| v.name.is_none())
                 .map(|v| emit_rvalue(&v.expr, compiler))
                 .collect::<Result<Vec<_>, _>>()?;
+            unnamed_args.extend(
+                default_args
+                    .into_iter()
+                    .map(|v| compiler.find_or_create_literal(&v)),
+            );
             let named_args = argss
                 .iter()
                 .filter_map(|v| {
@@ -807,7 +890,7 @@ fn emit_expr(expr: &Expression, compiler: &mut Compiler) -> Result<usize, String
                 if let Some((f_idx, _)) = fn_args
                     .iter()
                     .enumerate()
-                    .find(|(_, fn_arg_name)| *fn_arg_name == *arg.0)
+                    .find(|(_, fn_arg)| fn_arg.name == *arg.0)
                 {
                     args[f_idx] = Some(arg.1);
                 }

--- a/parser/src/compiler.rs
+++ b/parser/src/compiler.rs
@@ -211,7 +211,14 @@ impl Bytecode {
     }
 
     pub fn write(&self, writer: &mut impl Write) -> std::io::Result<()> {
-        writer.write_all(&self.functions.len().to_le_bytes())?;
+        writer.write_all(
+            &self
+                .functions
+                .iter()
+                .filter(|f| matches!(f.1, FnProto::Code(_)))
+                .count()
+                .to_le_bytes(),
+        )?;
         for (fname, func) in self.functions.iter() {
             if let FnProto::Code(func) = func {
                 write_str(fname, writer)?;

--- a/parser/src/compiler.rs
+++ b/parser/src/compiler.rs
@@ -1028,3 +1028,6 @@ fn emit_binary_op(
     });
     lhs
 }
+
+#[cfg(test)]
+mod test;

--- a/parser/src/compiler.rs
+++ b/parser/src/compiler.rs
@@ -1028,6 +1028,3 @@ fn emit_binary_op(
     });
     lhs
 }
-
-#[cfg(test)]
-mod test;

--- a/parser/src/compiler/test.rs
+++ b/parser/src/compiler/test.rs
@@ -1,0 +1,32 @@
+use super::*;
+
+#[test]
+fn test_default_arg() {
+    let src = r#"
+fn add(a: i32 = 123, b: i32 = 456) {
+    a + b;
+}
+
+output(add());
+"#;
+    let (_, ast) = crate::source(src).unwrap();
+    let buf = Rc::new(RefCell::new(vec![]));
+    let output = s_writer(buf.clone());
+    let mut funcs = HashMap::new();
+    funcs.insert("output".to_string(), output);
+    let bytecode = compile(&ast, funcs).unwrap();
+    crate::interpret(&bytecode).unwrap();
+    assert_eq!(*buf.borrow(), b"579");
+}
+
+pub(crate) fn s_writer(
+    out: Rc<RefCell<Vec<u8>>>,
+) -> Box<dyn Fn(&[Value]) -> Result<Value, EvalError>> {
+    Box::new(move |vals| {
+        let mut writer = out.borrow_mut();
+        for val in vals {
+            write!(writer, "{}", val).unwrap();
+        }
+        Ok(Value::I32(0))
+    })
+}

--- a/parser/src/interpreter.rs
+++ b/parser/src/interpreter.rs
@@ -291,7 +291,7 @@ pub(crate) fn eval<'a, 'b>(
                 FuncDef::Code(func) => {
                     for (name, val) in named_args.into_iter() {
                         if let Some((i, _decl_arg)) =
-                            func.args.iter().enumerate().find(|f| f.1 .0 == **name)
+                            func.args.iter().enumerate().find(|f| f.1 .name == **name)
                         {
                             if eval_args.len() <= i {
                                 eval_args.resize(i + 1, RunResult::Yield(Value::I32(0)));
@@ -304,8 +304,8 @@ pub(crate) fn eval<'a, 'b>(
 
                     for (k, v) in func.args.iter().zip(&eval_args) {
                         subctx.variables.borrow_mut().insert(
-                            k.0,
-                            Rc::new(RefCell::new(coerce_type(&unwrap_run!(v.clone()), &k.1)?)),
+                            k.name,
+                            Rc::new(RefCell::new(coerce_type(&unwrap_run!(v.clone()), &k.ty)?)),
                         );
                     }
                     let run_result = run(func.stmts, &mut subctx)?;
@@ -737,13 +737,13 @@ pub(crate) fn std_functions<'src, 'ast, 'native>() -> HashMap<String, FuncDef<'s
     );
     functions.insert(
         "puts".to_string(),
-        FuncDef::new_native(&s_puts, vec![ArgDecl("val", TypeDecl::Any)], None),
+        FuncDef::new_native(&s_puts, vec![ArgDecl::new("val", TypeDecl::Any)], None),
     );
     functions.insert(
         "type".to_string(),
         FuncDef::new_native(
             &s_type,
-            vec![ArgDecl("value", TypeDecl::Any)],
+            vec![ArgDecl::new("value", TypeDecl::Any)],
             Some(TypeDecl::Str),
         ),
     );
@@ -751,7 +751,7 @@ pub(crate) fn std_functions<'src, 'ast, 'native>() -> HashMap<String, FuncDef<'s
         "len".to_string(),
         FuncDef::new_native(
             &s_len,
-            vec![ArgDecl("array", TypeDecl::Array(Box::new(TypeDecl::Any)))],
+            vec![ArgDecl::new("array", TypeDecl::Array(Box::new(TypeDecl::Any)))],
             Some(TypeDecl::I64),
         ),
     );
@@ -760,8 +760,8 @@ pub(crate) fn std_functions<'src, 'ast, 'native>() -> HashMap<String, FuncDef<'s
         FuncDef::new_native(
             &s_push,
             vec![
-                ArgDecl("array", TypeDecl::Array(Box::new(TypeDecl::Any))),
-                ArgDecl("value", TypeDecl::Any),
+                ArgDecl::new("array", TypeDecl::Array(Box::new(TypeDecl::Any))),
+                ArgDecl::new("value", TypeDecl::Any),
             ],
             None,
         ),
@@ -770,7 +770,7 @@ pub(crate) fn std_functions<'src, 'ast, 'native>() -> HashMap<String, FuncDef<'s
         "hex_string".to_string(),
         FuncDef::new_native(
             &s_hex_string,
-            vec![ArgDecl("value", TypeDecl::I64)],
+            vec![ArgDecl::new("value", TypeDecl::I64)],
             Some(TypeDecl::Str),
         ),
     );

--- a/parser/src/interpreter.rs
+++ b/parser/src/interpreter.rs
@@ -280,6 +280,10 @@ where
                     fn_args
                         .into_iter()
                         .filter_map(|arg| {
+                            // We use a new temporary EvalContext to avoid referencing outer variables, i.e. make it
+                            // a constant expression, in order to match the semantics with the bytecode compiler.
+                            // Theoretically, it is possible to evaluate the expression ahead of time to reduce
+                            // computation, but our priority is bytecode compiler which already does constant folding.
                             arg.init
                                 .as_ref()
                                 .map(|init| eval(init, &mut EvalContext::new()))
@@ -684,14 +688,12 @@ impl<'src, 'ast, 'native> FuncDef<'src, 'native> {
 
 /// A context stat for evaluating a script.
 ///
-/// It has 4 lifetime arguments:
+/// It has 3 lifetime arguments:
 ///  * the source code ('src)
-///  * the AST ('ast),
 ///  * the native function code ('native) and
 ///  * the parent eval context ('ctx)
 ///
-/// In general, they all can have different lifetimes. For example,
-/// usually AST is created after the source.
+/// In general, they all can have different lifetimes.
 #[derive(Clone)]
 pub struct EvalContext<'src, 'native, 'ctx> {
     /// RefCell to allow mutation in super context.

--- a/parser/src/interpreter.rs
+++ b/parser/src/interpreter.rs
@@ -666,7 +666,7 @@ pub enum FuncDef<'src, 'native> {
     Native(NativeCode<'native>),
 }
 
-impl<'src, 'ast, 'native> FuncDef<'src, 'native> {
+impl<'src, 'native> FuncDef<'src, 'native> {
     pub fn new_native(
         code: &'native dyn Fn(&[Value]) -> Result<Value, EvalError>,
         args: Vec<ArgDecl<'native>>,

--- a/parser/src/interpreter.rs
+++ b/parser/src/interpreter.rs
@@ -279,7 +279,11 @@ where
 
                     fn_args
                         .into_iter()
-                        .filter_map(|arg| arg.init.as_ref().map(|init| eval(init, ctx)))
+                        .filter_map(|arg| {
+                            arg.init
+                                .as_ref()
+                                .map(|init| eval(init, &mut EvalContext::new()))
+                        })
                         .collect::<Result<Vec<_>, _>>()?
                 } else {
                     vec![]

--- a/parser/src/interpreter.rs
+++ b/parser/src/interpreter.rs
@@ -622,12 +622,12 @@ pub struct FuncCode<'src> {
     pub(crate) ret_type: Option<TypeDecl>,
     /// Owning a clone of AST of statements is not quite efficient, but we could not get
     /// around the borrow checker.
-    stmts: Vec<Statement<'src>>,
+    stmts: Rc<Vec<Statement<'src>>>,
 }
 
 impl<'src> FuncCode<'src> {
     pub(crate) fn new(
-        stmts: Vec<Statement<'src>>,
+        stmts: Rc<Vec<Statement<'src>>>,
         args: Vec<ArgDecl<'src>>,
         ret_type: Option<TypeDecl>,
     ) -> Self {

--- a/parser/src/interpreter/test.rs
+++ b/parser/src/interpreter/test.rs
@@ -632,7 +632,7 @@ fn fn_array_decl_test() {
         func_decl(span).finish().unwrap().1,
         Statement::FnDecl {
             name: "f",
-            args: vec![ArgDecl("a", TypeDecl::Array(Box::new(TypeDecl::I32)))],
+            args: vec![ArgDecl::new("a", TypeDecl::Array(Box::new(TypeDecl::I32)))],
             ret_type: None,
             stmts: vec![Statement::Expression(Expression::new(
                 VarAssign(

--- a/parser/src/interpreter/test.rs
+++ b/parser/src/interpreter/test.rs
@@ -133,6 +133,21 @@ fn fn_invoke_test() {
     );
 }
 
+#[test]
+fn fn_default_test() {
+    let span = Span::new("fn a(a: i32 = 1) { a; }");
+    let stmts = source(span).finish();
+    assert!(stmts.is_ok());
+}
+
+#[test]
+fn fn_default_failure_test() {
+    let span = Span::new("var b = 1; fn f(a: i32 = b) { a; } f()");
+    let stmts = source(span).finish().unwrap().1;
+    let res = run(&stmts, &mut EvalContext::new());
+    assert_eq!(res, Err("Variable b not found in scope".to_string()));
+}
+
 fn span_conditional(s: &str) -> IResult<Span, Expression> {
     conditional(Span::new(s))
 }

--- a/parser/src/interpreter/test.rs
+++ b/parser/src/interpreter/test.rs
@@ -650,13 +650,13 @@ fn fn_array_decl_test() {
             name: "f",
             args: vec![ArgDecl::new("a", TypeDecl::Array(Box::new(TypeDecl::I32)))],
             ret_type: None,
-            stmts: vec![Statement::Expression(Expression::new(
+            stmts: Rc::new(vec![Statement::Expression(Expression::new(
                 VarAssign(
                     var_r(span.subslice(17, 1)),
                     bnl(Value::I64(123), span.subslice(21, 3))
                 ),
                 span.subslice(17, 7)
-            ))]
+            ))])
         }
     );
 }

--- a/parser/src/interpreter/test.rs
+++ b/parser/src/interpreter/test.rs
@@ -140,6 +140,7 @@ fn fn_default_test() {
     assert!(stmts.is_ok());
 }
 
+/// Tests non-const default argument expression will fail to evaluate
 #[test]
 fn fn_default_failure_test() {
     let span = Span::new("var b = 1; fn f(a: i32 = b) { a; } f()");

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -43,7 +43,7 @@ impl From<ReadError> for String {
 }
 
 #[derive(Debug, PartialEq, Clone)]
-pub struct ArgDecl<'a>{
+pub struct ArgDecl<'a> {
     pub name: &'a str,
     pub ty: TypeDecl,
     pub init: Option<Expression<'a>>,
@@ -52,7 +52,9 @@ pub struct ArgDecl<'a>{
 impl<'a> ArgDecl<'a> {
     pub fn new(name: &'a str, ty: TypeDecl) -> Self {
         Self {
-            name, ty, init: None
+            name,
+            ty,
+            init: None,
         }
     }
 }
@@ -619,11 +621,14 @@ pub(crate) fn func_arg(r: Span) -> IResult<Span, ArgDecl> {
     let (r, id) = identifier(r)?;
     let (r, ty) = opt(ws(type_spec))(r)?;
     let (r, init) = opt(preceded(ws(char('=')), full_expression))(r)?;
-    Ok((r, ArgDecl{
-        name: *id,
-        ty: ty.unwrap_or(TypeDecl::F64),
-        init,
-    }))
+    Ok((
+        r,
+        ArgDecl {
+            name: *id,
+            ty: ty.unwrap_or(TypeDecl::F64),
+            init,
+        },
+    ))
 }
 
 pub(crate) fn func_decl(input: Span) -> IResult<Span, Statement> {

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -11,7 +11,7 @@ use nom::{
     IResult, InputTake, Offset,
 };
 use nom_locate::LocatedSpan;
-use std::string::FromUtf8Error;
+use std::{rc::Rc, string::FromUtf8Error};
 
 pub type Span<'a> = LocatedSpan<&'a str>;
 
@@ -67,7 +67,7 @@ pub enum Statement<'a> {
         name: &'a str,
         args: Vec<ArgDecl<'a>>,
         ret_type: Option<TypeDecl>,
-        stmts: Vec<Statement<'a>>,
+        stmts: Rc<Vec<Statement<'a>>>,
     },
     Expression(Expression<'a>),
     Loop(Vec<Statement<'a>>),
@@ -647,7 +647,7 @@ pub(crate) fn func_decl(input: Span) -> IResult<Span, Statement> {
             name: *name,
             args,
             ret_type,
-            stmts,
+            stmts: Rc::new(stmts),
         },
     ))
 }

--- a/parser/src/parser/test.rs
+++ b/parser/src/parser/test.rs
@@ -330,7 +330,7 @@ fn fn_decl_test() {
         func_decl(span).finish().unwrap().1,
         Statement::FnDecl {
             name: "f",
-            args: vec![ArgDecl("a", TypeDecl::Any)],
+            args: vec![ArgDecl::new("a", TypeDecl::Any)],
             ret_type: None,
             stmts: vec![
                 Statement::Expression(Expression::new(
@@ -352,14 +352,14 @@ fn fn_decl_test() {
     );
     assert_eq!(
         func_arg(Span::new("a: i32")).finish().unwrap().1,
-        ArgDecl("a", TypeDecl::I32)
+        ArgDecl::new("a", TypeDecl::I32)
     );
     let span = Span::new("fn f(a: i32) { a * 2 }");
     assert_eq!(
         func_decl(span).finish().unwrap().1,
         Statement::FnDecl {
             name: "f",
-            args: vec![ArgDecl("a", TypeDecl::I32)],
+            args: vec![ArgDecl::new("a", TypeDecl::I32)],
             ret_type: None,
             stmts: vec![Statement::Expression(Expression::new(
                 Mult(
@@ -378,7 +378,7 @@ fn fn_decl_test() {
         func_decl(span).finish().unwrap().1,
         Statement::FnDecl {
             name: "f",
-            args: vec![ArgDecl("a", TypeDecl::I32)],
+            args: vec![ArgDecl::new("a", TypeDecl::I32)],
             ret_type: Some(TypeDecl::F64),
             stmts: vec![Statement::Expression(Expression::new(
                 Mult(

--- a/parser/src/parser/test.rs
+++ b/parser/src/parser/test.rs
@@ -332,7 +332,7 @@ fn fn_decl_test() {
             name: "f",
             args: vec![ArgDecl::new("a", TypeDecl::Any)],
             ret_type: None,
-            stmts: vec![
+            stmts: Rc::new(vec![
                 Statement::Expression(Expression::new(
                     VarAssign(
                         var_r(span.subslice(14, 1)),
@@ -347,7 +347,7 @@ fn fn_decl_test() {
                     Mult(var_r(span.subslice(27, 1)), var_r(span.subslice(31, 1))),
                     span.subslice(27, 5)
                 ))
-            ]
+            ])
         }
     );
     assert_eq!(
@@ -361,7 +361,7 @@ fn fn_decl_test() {
             name: "f",
             args: vec![ArgDecl::new("a", TypeDecl::I32)],
             ret_type: None,
-            stmts: vec![Statement::Expression(Expression::new(
+            stmts: Rc::new(vec![Statement::Expression(Expression::new(
                 Mult(
                     var_r(span.subslice(15, 1)),
                     Box::new(Expression::new(
@@ -370,7 +370,7 @@ fn fn_decl_test() {
                     ))
                 ),
                 span.subslice(15, 5)
-            ))]
+            ))])
         }
     );
     let span = Span::new("fn f(a: i32) -> f64 { a * 2 }");
@@ -380,7 +380,7 @@ fn fn_decl_test() {
             name: "f",
             args: vec![ArgDecl::new("a", TypeDecl::I32)],
             ret_type: Some(TypeDecl::F64),
-            stmts: vec![Statement::Expression(Expression::new(
+            stmts: Rc::new(vec![Statement::Expression(Expression::new(
                 Mult(
                     var_r(span.subslice(22, 1)),
                     Box::new(Expression::new(
@@ -389,7 +389,7 @@ fn fn_decl_test() {
                     ))
                 ),
                 span.subslice(22, 5)
-            ))]
+            ))])
         }
     );
 }

--- a/parser/src/type_checker.rs
+++ b/parser/src/type_checker.rs
@@ -154,7 +154,7 @@ fn tc_expr<'src, 'b>(
             })?;
             let args_decl = func.args();
             for ((arg_ty, arg), decl) in args_ty.iter().zip(args.iter()).zip(args_decl.iter()) {
-                tc_coerce_type(&arg_ty, &decl.1, arg.expr.span, ctx)?;
+                tc_coerce_type(&arg_ty, &decl.ty, arg.expr.span, ctx)?;
             }
             match func {
                 FuncDef::Code(code) => code.ret_type.clone().unwrap_or(TypeDecl::Any),
@@ -324,7 +324,7 @@ pub fn type_check<'src, 'ast>(
                 );
                 let mut subctx = TypeCheckContext::push_stack(ctx);
                 for arg in args.iter() {
-                    subctx.variables.insert(arg.0, arg.1.clone());
+                    subctx.variables.insert(arg.name, arg.ty.clone());
                 }
                 let last_stmt = type_check(stmts, &mut subctx)?;
                 if let Some((ret_type, Statement::Expression(ret_expr))) =

--- a/parser/tests/compiler.rs
+++ b/parser/tests/compiler.rs
@@ -10,19 +10,35 @@ fn add(a: i32 = 123, b: i32 = 456) {
 
 output(add());
 "#;
-    let (_, ast) = crate::source(src).unwrap();
+    parse_compile_interpret(src, b"579");
+}
+
+/// Tests the function default arguments with constant expression
+#[test]
+fn test_default_arg_const_expr() {
+    let src = r#"
+fn double(a: i32 = 1 + 2 + 3) {
+    a * 2;
+}
+
+output(double());
+"#;
+    parse_compile_interpret(src, b"12");
+}
+
+fn parse_compile_interpret(src: &str, expected: &[u8]) {
+    let (_, ast) = source(src).unwrap();
     let buf = Rc::new(RefCell::new(vec![]));
     let output = s_writer(buf.clone());
     let mut funcs = HashMap::new();
     funcs.insert("output".to_string(), output);
     let bytecode = compile(&ast, funcs).unwrap();
-    crate::interpret(&bytecode).unwrap();
-    assert_eq!(*buf.borrow(), b"579");
+    interpret(&bytecode).unwrap();
+    assert_eq!(*buf.borrow(), expected);
 }
 
-pub(crate) fn s_writer(
-    out: Rc<RefCell<Vec<u8>>>,
-) -> Box<dyn Fn(&[Value]) -> Result<Value, EvalError>> {
+/// Take an output mutable shared buffer behind Rc-RefCell, returns a closure that writes to it.
+fn s_writer(out: Rc<RefCell<Vec<u8>>>) -> Box<dyn Fn(&[Value]) -> Result<Value, EvalError>> {
     Box::new(move |vals| {
         let mut writer = out.borrow_mut();
         for val in vals {

--- a/parser/tests/compiler.rs
+++ b/parser/tests/compiler.rs
@@ -1,3 +1,4 @@
+use nom::Finish;
 use parser::*;
 use std::{cell::RefCell, collections::HashMap, io::Write, rc::Rc};
 
@@ -27,7 +28,7 @@ output(double());
 }
 
 fn parse_compile_interpret(src: &str, expected: &[u8]) {
-    let (_, ast) = source(src).unwrap();
+    let (_, ast) = source(src).finish().unwrap();
     let buf = Rc::new(RefCell::new(vec![]));
     let output = s_writer(buf.clone());
     let mut funcs = HashMap::new();

--- a/parser/tests/compiler.rs
+++ b/parser/tests/compiler.rs
@@ -1,4 +1,5 @@
-use super::*;
+use parser::*;
+use std::{cell::RefCell, collections::HashMap, io::Write, rc::Rc};
 
 #[test]
 fn test_default_arg() {

--- a/scripts/fn_default.dragon
+++ b/scripts/fn_default.dragon
@@ -1,0 +1,8 @@
+
+/* add two values */
+fn add(a: i32 = 123, b: i32 = 456) {
+    a + b;
+}
+
+// print(add(123, 456));
+print(add());

--- a/scripts/fn_default_const.dragon
+++ b/scripts/fn_default_const.dragon
@@ -1,0 +1,6 @@
+
+fn double(a: i32 = 1 + 2 + 3) {
+    a * 2;
+}
+
+print(double());

--- a/scripts/fn_default_expr.dragon
+++ b/scripts/fn_default_expr.dragon
@@ -1,0 +1,12 @@
+
+var c = 1;
+
+/* Note that the default arg expressions are evaluated at call time,
+   not definition time. This is the same behavior as C++ but different from Python. */
+fn add(a: i32 = c * 2, b: i32 = c * 3) {
+    a + b;
+}
+
+c = 10;
+
+print(add());

--- a/scripts/line_comment.dragon
+++ b/scripts/line_comment.dragon
@@ -10,6 +10,8 @@ fn add          // inline comment
 
 var // inline comment
     a // inline comment
+    : // inline comment
+    i32 // inline comment
     = 123;
 
 var b = // inline comment

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -117,13 +117,13 @@ macro_rules! wasm_functions {
         $ctx.set_fn("print", FuncDef::new_native(&s_print, vec![], None));
         $ctx.set_fn(
             "puts",
-            FuncDef::new_native(&s_puts, vec![ArgDecl("val", TypeDecl::Any)], None),
+            FuncDef::new_native(&s_puts, vec![ArgDecl::new("val", TypeDecl::Any)], None),
         );
         $ctx.set_fn(
             "set_fill_style",
             FuncDef::new_native(
                 &s_set_fill_style,
-                vec![ArgDecl("style", TypeDecl::Str)],
+                vec![ArgDecl::new("style", TypeDecl::Str)],
                 None,
             ),
         );
@@ -132,10 +132,10 @@ macro_rules! wasm_functions {
             FuncDef::new_native(
                 &s_rectangle,
                 vec![
-                    ArgDecl("x0", TypeDecl::I64),
-                    ArgDecl("y0", TypeDecl::I64),
-                    ArgDecl("x1", TypeDecl::I64),
-                    ArgDecl("y1", TypeDecl::I64),
+                    ArgDecl::new("x0", TypeDecl::I64),
+                    ArgDecl::new("y0", TypeDecl::I64),
+                    ArgDecl::new("x1", TypeDecl::I64),
+                    ArgDecl::new("y1", TypeDecl::I64),
                 ],
                 None,
             ),


### PR DESCRIPTION
This feature exists in C++, Python and many other languages (but interestingly not in Rust).

You can define a function like this:

```
fn add(a: i32 = 1, b: i32 = 2) -> i32 {
    a + b;
}
```

and you can call this function without explicit arguments:

```
print(add());
```

and it should print `3`.

You can also partially provide an argument:

```
print(add(1000));
```

which should print `1002`.

See the [wiki](https://github.com/msakuta/rusty-parser/wiki/Function-signature#default-argument) for more details.
