### PR TITLE
Sized array support in static type checker

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -87,7 +87,7 @@ fn main() -> Result<(), String> {
             }
         } else {
             run(&result.1, &mut EvalContext::new())
-                .map_err(|e| format!("Error in run(): {:?}", e))?;
+                .map_err(|e| format!("Error in run(): {}", e))?;
         }
 
         Ok(())

--- a/parser/src/bytecode.rs
+++ b/parser/src/bytecode.rs
@@ -165,17 +165,20 @@ fn read_str(reader: &mut impl Read) -> Result<String, ReadError> {
     Ok(String::from_utf8(buf)?)
 }
 
-fn write_bool(b: bool, writer: &mut impl Write) -> std::io::Result<()> {
+pub(crate) fn write_bool(b: bool, writer: &mut impl Write) -> std::io::Result<()> {
     writer.write_all(&[if b { 1u8 } else { 0u8 }])
 }
 
-fn read_bool(reader: &mut impl Read) -> Result<bool, ReadError> {
+pub(crate) fn read_bool(reader: &mut impl Read) -> Result<bool, ReadError> {
     let mut buf = [0u8; 1];
     reader.read_exact(&mut buf)?;
     Ok(buf[0] != 0)
 }
 
-fn write_opt_value(value: &Option<Value>, writer: &mut impl Write) -> std::io::Result<()> {
+pub(crate) fn write_opt_value(
+    value: &Option<Value>,
+    writer: &mut impl Write,
+) -> std::io::Result<()> {
     write_bool(value.is_some(), writer)?;
     if let Some(value) = value {
         value.serialize(writer)?;
@@ -183,7 +186,7 @@ fn write_opt_value(value: &Option<Value>, writer: &mut impl Write) -> std::io::R
     Ok(())
 }
 
-fn read_opt_value(reader: &mut impl Read) -> Result<Option<Value>, ReadError> {
+pub(crate) fn read_opt_value(reader: &mut impl Read) -> Result<Option<Value>, ReadError> {
     let has_value = read_bool(reader)?;
     Ok(if has_value {
         Some(Value::deserialize(reader)?)

--- a/parser/src/interpreter.rs
+++ b/parser/src/interpreter.rs
@@ -355,12 +355,20 @@ pub fn coerce_type(value: &Value, target: &TypeDecl) -> Result<Value, EvalError>
         TypeDecl::I64 => Value::I64(coerce_i64(value)?),
         TypeDecl::I32 => Value::I32(coerce_i64(value)? as i32),
         TypeDecl::Str => Value::Str(coerce_str(value)?),
-        TypeDecl::Array(inner) => {
+        TypeDecl::Array(inner, len) => {
             if let Value::Array(array) = value {
+                let array = array.borrow();
+                if let Some(len) = len {
+                    if *len != array.values.len() {
+                        return Err(EvalError::CoerceError(
+                            inner.to_string(),
+                            TypeDecl::from_value(&value).to_string(),
+                        ));
+                    }
+                }
                 Value::Array(ArrayInt::new(
                     (**inner).clone(),
                     array
-                        .borrow()
                         .values
                         .iter()
                         .map(|value_elem| -> Result<_, EvalError> {
@@ -998,7 +1006,7 @@ pub(crate) fn std_functions<'src, 'native>() -> HashMap<String, FuncDef<'src, 'n
             &s_len,
             vec![ArgDecl::new(
                 "array",
-                TypeDecl::Array(Box::new(TypeDecl::Any)),
+                TypeDecl::Array(Box::new(TypeDecl::Any), None),
             )],
             Some(TypeDecl::I64),
         ),
@@ -1008,7 +1016,7 @@ pub(crate) fn std_functions<'src, 'native>() -> HashMap<String, FuncDef<'src, 'n
         FuncDef::new_native(
             &s_push,
             vec![
-                ArgDecl::new("array", TypeDecl::Array(Box::new(TypeDecl::Any))),
+                ArgDecl::new("array", TypeDecl::Array(Box::new(TypeDecl::Any), None)),
                 ArgDecl::new("value", TypeDecl::Any),
             ],
             None,

--- a/parser/src/interpreter.rs
+++ b/parser/src/interpreter.rs
@@ -1009,7 +1009,7 @@ pub(crate) fn std_functions<'src, 'native>() -> HashMap<String, FuncDef<'src, 'n
             vec![
                 ArgDecl::new(
                     "array",
-                    TypeDecl::Array(Box::new(TypeDecl::Any), ArraySize::Dynamic),
+                    TypeDecl::Array(Box::new(TypeDecl::Any), ArraySize::Range(0..usize::MAX)),
                 ),
                 ArgDecl::new("value", TypeDecl::Any),
             ],

--- a/parser/src/interpreter.rs
+++ b/parser/src/interpreter.rs
@@ -1,5 +1,6 @@
 use crate::{
     parser::*,
+    type_decl::ArraySize,
     value::{ArrayInt, TupleEntry},
     TypeDecl, Value,
 };
@@ -365,7 +366,7 @@ pub fn coerce_type(value: &Value, target: &TypeDecl) -> Result<Value, EvalError>
         TypeDecl::Array(inner, len) => {
             if let Value::Array(array) = value {
                 let array = array.borrow();
-                if let Some(len) = len {
+                if let ArraySize::Fixed(len) = len {
                     if *len != array.values.len() {
                         return Err(EvalError::IncompatibleArrayLength(*len, array.values.len()));
                     }
@@ -996,7 +997,7 @@ pub(crate) fn std_functions<'src, 'native>() -> HashMap<String, FuncDef<'src, 'n
             &s_len,
             vec![ArgDecl::new(
                 "array",
-                TypeDecl::Array(Box::new(TypeDecl::Any), None),
+                TypeDecl::Array(Box::new(TypeDecl::Any), ArraySize::Any),
             )],
             Some(TypeDecl::I64),
         ),
@@ -1006,7 +1007,10 @@ pub(crate) fn std_functions<'src, 'native>() -> HashMap<String, FuncDef<'src, 'n
         FuncDef::new_native(
             &s_push,
             vec![
-                ArgDecl::new("array", TypeDecl::Array(Box::new(TypeDecl::Any), None)),
+                ArgDecl::new(
+                    "array",
+                    TypeDecl::Array(Box::new(TypeDecl::Any), ArraySize::Dynamic),
+                ),
                 ArgDecl::new("value", TypeDecl::Any),
             ],
             None,

--- a/parser/src/interpreter.rs
+++ b/parser/src/interpreter.rs
@@ -44,6 +44,7 @@ pub enum EvalError {
     NoMainFound,
     NonNameFnRef(String),
     CallStackUndeflow,
+    IncompatibleArrayLength(usize, usize),
 }
 
 impl std::error::Error for EvalError {}
@@ -100,6 +101,10 @@ impl std::fmt::Display for EvalError {
                 "Function can be only specified by a name (yet), but got {val}"
             ),
             Self::CallStackUndeflow => write!(f, "Call stack underflow!"),
+            Self::IncompatibleArrayLength(dst, src) => write!(
+                f,
+                "Array length is incompatible; tried to assign {src} to {dst}"
+            ),
         }
     }
 }
@@ -360,10 +365,7 @@ pub fn coerce_type(value: &Value, target: &TypeDecl) -> Result<Value, EvalError>
                 let array = array.borrow();
                 if let Some(len) = len {
                     if *len != array.values.len() {
-                        return Err(EvalError::CoerceError(
-                            inner.to_string(),
-                            TypeDecl::from_value(&value).to_string(),
-                        ));
+                        return Err(EvalError::IncompatibleArrayLength(*len, array.values.len()));
                     }
                 }
                 Value::Array(ArrayInt::new(

--- a/parser/src/interpreter.rs
+++ b/parser/src/interpreter.rs
@@ -486,12 +486,15 @@ where
                 .clone();
 
             let mut eval_args = vec![None; fn_args.len().max(args.len())];
+
+            // Fill unnamed args
             for (arg, eval_arg) in args.iter().zip(eval_args.iter_mut()) {
                 if arg.name.is_none() {
                     *eval_arg = Some(eval(&arg.expr, ctx)?);
                 }
             }
 
+            // Find and assign named args
             for arg in args.iter() {
                 if let Some(name) = arg.name {
                     if let Some(eval_arg) = fn_args

--- a/parser/src/interpreter/test.rs
+++ b/parser/src/interpreter/test.rs
@@ -784,7 +784,7 @@ fn array_sized_error_test() {
     let ast = source(span).finish().unwrap().1;
     match type_check(&ast, &mut TypeCheckContext::new(Some("input"))) {
         Ok(_) => panic!(),
-        Err(e) => assert_eq!(e.to_string(), "Operation Assignment between incompatible type Array(I32, Fixed(3)) and Array(I32, Fixed(4)): Array size is not compatible: 3 cannot assign to 4\ninput:1:57"),
+        Err(e) => assert_eq!(e.to_string(), "Operation Assignment between incompatible type [i32; 3] and [i32; 4]: Array size is not compatible: 3 cannot assign to 4\ninput:1:57"),
     }
     // It will run successfully although the typecheck fails.
     run0(&ast).unwrap();

--- a/parser/src/interpreter/test.rs
+++ b/parser/src/interpreter/test.rs
@@ -784,10 +784,22 @@ fn array_sized_error_test() {
     let ast = source(span).finish().unwrap().1;
     match type_check(&ast, &mut TypeCheckContext::new(Some("input"))) {
         Ok(_) => panic!(),
-        Err(e) => assert_eq!(e.to_string(), "Operation Assignment between incompatible type [i32; 3] and [i32; 4]: Array size is not compatible: 3 cannot assign to 4\ninput:1:57"),
+        Err(e) => assert_eq!(e.to_string(), "Operation Assignment between incompatible type [i32; 3] and [i32; 4]: Array size is not compatible: 4 cannot assign to 3\ninput:1:57"),
     }
     // It will run successfully although the typecheck fails.
     run0(&ast).unwrap();
+}
+
+#[test]
+fn array_sized_cmp_error_test() {
+    let span = Span::new("var a: [i32; 3] = [1,2,3]; var b: [i32; 4] = [4,5,6,7]; a < b;");
+    let ast = source(span).finish().unwrap().1;
+    match type_check(&ast, &mut TypeCheckContext::new(Some("input"))) {
+        Ok(_) => panic!(),
+        Err(e) => assert_eq!(e.to_string(), "Operation LT between incompatible type [i32; 3] and [i32; 4]: Array size must be the same for comparison\ninput:1:57"),
+    }
+    // It will fail at runtime
+    assert!(run0(&ast).is_err());
 }
 
 #[test]

--- a/parser/src/interpreter/test.rs
+++ b/parser/src/interpreter/test.rs
@@ -553,18 +553,18 @@ fn array_decl_test() {
     );
     assert_eq!(
         type_spec(Span::new(": [i32]")).finish().unwrap().1,
-        TypeDecl::Array(Box::new(TypeDecl::I32), None)
+        TypeDecl::Array(Box::new(TypeDecl::I32), ArraySize::Any)
     );
     assert_eq!(
         type_spec(Span::new(": [[f32]]")).finish().unwrap().1,
         TypeDecl::Array(
-            Box::new(TypeDecl::Array(Box::new(TypeDecl::F32), None)),
-            None
+            Box::new(TypeDecl::Array(Box::new(TypeDecl::F32), ArraySize::Any)),
+            ArraySize::Any
         )
     );
     assert_eq!(
         type_spec(Span::new(": [f32; 3]")).finish().unwrap().1,
-        TypeDecl::Array(Box::new(TypeDecl::F32), Some(3))
+        TypeDecl::Array(Box::new(TypeDecl::F32), ArraySize::Fixed(3))
     );
 }
 
@@ -660,7 +660,7 @@ fn fn_array_decl_test() {
             name: "f",
             args: vec![ArgDecl::new(
                 "a",
-                TypeDecl::Array(Box::new(TypeDecl::I32), None)
+                TypeDecl::Array(Box::new(TypeDecl::I32), ArraySize::Any)
             )],
             ret_type: None,
             stmts: Rc::new(vec![Statement::Expression(Expression::new(
@@ -784,7 +784,7 @@ fn array_sized_error_test() {
     let ast = source(span).finish().unwrap().1;
     match type_check(&ast, &mut TypeCheckContext::new(Some("input"))) {
         Ok(_) => panic!(),
-        Err(e) => assert_eq!(e.to_string(), "Operation Assignment between incompatible type: Array(I32, Some(3)) and Array(I32, Some(4))\ninput:1:57"),
+        Err(e) => assert_eq!(e.to_string(), "Operation Assignment between incompatible type: Array(I32, Fixed(3)) and Array(I32, Fixed(4))\ninput:1:57"),
     }
     // It will run successfully although the typecheck fails.
     run0(&ast).unwrap();

--- a/parser/src/interpreter/test.rs
+++ b/parser/src/interpreter/test.rs
@@ -550,11 +550,18 @@ fn array_decl_test() {
     );
     assert_eq!(
         type_spec(Span::new(": [i32]")).finish().unwrap().1,
-        TypeDecl::Array(Box::new(TypeDecl::I32))
+        TypeDecl::Array(Box::new(TypeDecl::I32), None)
     );
     assert_eq!(
         type_spec(Span::new(": [[f32]]")).finish().unwrap().1,
-        TypeDecl::Array(Box::new(TypeDecl::Array(Box::new(TypeDecl::F32))))
+        TypeDecl::Array(
+            Box::new(TypeDecl::Array(Box::new(TypeDecl::F32), None)),
+            None
+        )
+    );
+    assert_eq!(
+        type_spec(Span::new(": [f32; 3]")).finish().unwrap().1,
+        TypeDecl::Array(Box::new(TypeDecl::F32), Some(3))
     );
 }
 
@@ -648,7 +655,10 @@ fn fn_array_decl_test() {
         func_decl(span).finish().unwrap().1,
         Statement::FnDecl {
             name: "f",
-            args: vec![ArgDecl::new("a", TypeDecl::Array(Box::new(TypeDecl::I32)))],
+            args: vec![ArgDecl::new(
+                "a",
+                TypeDecl::Array(Box::new(TypeDecl::I32), None)
+            )],
             ret_type: None,
             stmts: Rc::new(vec![Statement::Expression(Expression::new(
                 VarAssign(

--- a/parser/src/interpreter/test.rs
+++ b/parser/src/interpreter/test.rs
@@ -784,7 +784,7 @@ fn array_sized_error_test() {
     let ast = source(span).finish().unwrap().1;
     match type_check(&ast, &mut TypeCheckContext::new(Some("input"))) {
         Ok(_) => panic!(),
-        Err(e) => assert_eq!(e.to_string(), "Operation Assignment between incompatible type: Array(I32, Fixed(3)) and Array(I32, Fixed(4))\ninput:1:57"),
+        Err(e) => assert_eq!(e.to_string(), "Operation Assignment between incompatible type Array(I32, Fixed(3)) and Array(I32, Fixed(4)): Array size is not compatible: 3 cannot assign to 4\ninput:1:57"),
     }
     // It will run successfully although the typecheck fails.
     run0(&ast).unwrap();

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -215,8 +215,15 @@ fn type_scalar(input: Span) -> IResult<Span, TypeDecl> {
 }
 
 fn type_array(input: Span) -> IResult<Span, TypeDecl> {
-    let (r, arr) = delimited(ws(char('[')), type_decl, ws(char(']')))(input)?;
-    Ok((r, TypeDecl::Array(Box::new(arr))))
+    let (r, (arr, len)) = delimited(
+        ws(char('[')),
+        pair(type_decl, opt(preceded(tag(";"), ws(decimal)))),
+        ws(char(']')),
+    )(input)?;
+    Ok((
+        r,
+        TypeDecl::Array(Box::new(arr), len.and_then(|len| len.parse().ok())),
+    ))
 }
 
 fn type_tuple(i: Span) -> IResult<Span, TypeDecl> {

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -1,4 +1,7 @@
-use crate::{type_decl::TypeDecl, Value};
+use crate::{
+    type_decl::{ArraySize, TypeDecl},
+    Value,
+};
 
 use nom::{
     branch::alt,
@@ -222,7 +225,13 @@ fn type_array(input: Span) -> IResult<Span, TypeDecl> {
     )(input)?;
     Ok((
         r,
-        TypeDecl::Array(Box::new(arr), len.and_then(|len| len.parse().ok())),
+        TypeDecl::Array(
+            Box::new(arr),
+            match len.and_then(|len| len.parse().ok()) {
+                Some(len) => ArraySize::Fixed(len),
+                None => ArraySize::Any,
+            },
+        ),
     ))
 }
 

--- a/parser/src/parser/test.rs
+++ b/parser/src/parser/test.rs
@@ -800,3 +800,42 @@ fn test_tuple_decl() {
         )
     );
 }
+
+#[test]
+fn test_array_decl() {
+    let span = Span::new("var a: [i32] = [1, 2];");
+    assert_eq!(
+        statement(span).finish().unwrap().1,
+        Statement::VarDecl(
+            &*span.subslice(4, 1),
+            TypeDecl::Array(Box::new(TypeDecl::I32), None),
+            Some(Expression::new(
+                ArrLiteral(vec![
+                    Expression::new(NumLiteral(Value::I64(1)), span.subslice(16, 1)),
+                    Expression::new(NumLiteral(Value::I64(2)), span.subslice(19, 1)),
+                ]),
+                span.subslice(15, 6)
+            ))
+        )
+    );
+}
+
+#[test]
+fn test_fixed_sz_array() {
+    let span = Span::new("var a: [i32; 3] = [1, 2, 3];");
+    assert_eq!(
+        statement(span).finish().unwrap().1,
+        Statement::VarDecl(
+            &*span.subslice(4, 1),
+            TypeDecl::Array(Box::new(TypeDecl::I32), Some(3)),
+            Some(Expression::new(
+                ArrLiteral(vec![
+                    Expression::new(NumLiteral(Value::I64(1)), span.subslice(19, 1)),
+                    Expression::new(NumLiteral(Value::I64(2)), span.subslice(22, 1)),
+                    Expression::new(NumLiteral(Value::I64(3)), span.subslice(25, 1)),
+                ]),
+                span.subslice(18, 9)
+            ))
+        )
+    );
+}

--- a/parser/src/parser/test.rs
+++ b/parser/src/parser/test.rs
@@ -839,3 +839,36 @@ fn test_fixed_sz_array() {
         )
     );
 }
+
+#[test]
+fn test_range_sz_array() {
+    let span = Span::new("var a: [i32; ..];");
+    assert_eq!(
+        statement(span).finish().unwrap().1,
+        Statement::VarDecl(
+            &*span.subslice(4, 1),
+            TypeDecl::Array(Box::new(TypeDecl::I32), ArraySize::Range(0..usize::MAX)),
+            None
+        )
+    );
+
+    let span = Span::new("var a: [i32; 3..];");
+    assert_eq!(
+        statement(span).finish().unwrap().1,
+        Statement::VarDecl(
+            &*span.subslice(4, 1),
+            TypeDecl::Array(Box::new(TypeDecl::I32), ArraySize::Range(3..usize::MAX)),
+            None
+        )
+    );
+
+    let span = Span::new("var a: [i32; ..10];");
+    assert_eq!(
+        statement(span).finish().unwrap().1,
+        Statement::VarDecl(
+            &*span.subslice(4, 1),
+            TypeDecl::Array(Box::new(TypeDecl::I32), ArraySize::Range(0..10)),
+            None
+        )
+    );
+}

--- a/parser/src/parser/test.rs
+++ b/parser/src/parser/test.rs
@@ -808,7 +808,7 @@ fn test_array_decl() {
         statement(span).finish().unwrap().1,
         Statement::VarDecl(
             &*span.subslice(4, 1),
-            TypeDecl::Array(Box::new(TypeDecl::I32), None),
+            TypeDecl::Array(Box::new(TypeDecl::I32), ArraySize::Any),
             Some(Expression::new(
                 ArrLiteral(vec![
                     Expression::new(NumLiteral(Value::I64(1)), span.subslice(16, 1)),
@@ -827,7 +827,7 @@ fn test_fixed_sz_array() {
         statement(span).finish().unwrap().1,
         Statement::VarDecl(
             &*span.subslice(4, 1),
-            TypeDecl::Array(Box::new(TypeDecl::I32), Some(3)),
+            TypeDecl::Array(Box::new(TypeDecl::I32), ArraySize::Fixed(3)),
             Some(Expression::new(
                 ArrLiteral(vec![
                     Expression::new(NumLiteral(Value::I64(1)), span.subslice(19, 1)),

--- a/parser/src/type_checker.rs
+++ b/parser/src/type_checker.rs
@@ -370,7 +370,7 @@ fn tc_coerce_type<'src>(
                         ));
                     }
                 }
-                (ArraySize::Dynamic, ArraySize::Dynamic) => {}
+                (ArraySize::Dynamic | ArraySize::Any, ArraySize::Dynamic) => {}
                 _ => {
                     return Err(TypeCheckError::new(format!("Array size constraint is not compatible between {v_len:?} and {t_len:?}"), span, ctx.source_file));
                 }

--- a/parser/src/type_checker.rs
+++ b/parser/src/type_checker.rs
@@ -362,9 +362,11 @@ fn tc_coerce_type<'src>(
             match (v_len, t_len) {
                 (_, ArraySize::Any) => {}
                 (ArraySize::Fixed(v_len), ArraySize::Fixed(t_len)) => {
-                    if v_len < t_len {
+                    if v_len != t_len {
                         return Err(TypeCheckError::new(
-                            "Assignee array is smaller than assigner".to_string(),
+                            format!(
+                                "Array size is not compatible: {v_len} cannot assign to {t_len}"
+                            ),
                             span,
                             ctx.source_file,
                         ));

--- a/parser/src/type_checker.rs
+++ b/parser/src/type_checker.rs
@@ -167,7 +167,7 @@ where
                 .args();
 
             let args_decl = if args.len() <= fn_args.len() {
-                let fn_args = fn_args[args.len()..].to_vec();
+                let fn_args = fn_args[..args.len()].to_vec();
 
                 fn_args
                     .into_iter()

--- a/parser/src/type_checker.rs
+++ b/parser/src/type_checker.rs
@@ -358,7 +358,7 @@ fn tc_array_size(value: &ArraySize, target: &ArraySize) -> Result<(), String> {
             array_range_verify(t_range)?;
             if t_range.end < v_range.end || v_range.start < t_range.start {
                 return Err(format!(
-                    "Array range is not compatible: {v_range:?} cannot assign to {t_range:?}"
+                    "Array range is not compatible: {value} cannot assign to {target}"
                 ));
             }
         }
@@ -366,7 +366,7 @@ fn tc_array_size(value: &ArraySize, target: &ArraySize) -> Result<(), String> {
             array_range_verify(t_range)?;
             if *v_len < t_range.start || t_range.end < *v_len {
                 return Err(format!(
-                    "Array range is not compatible: {v_len} cannot assign to {t_range:?}"
+                    "Array range is not compatible: {v_len} cannot assign to {target}"
                 ));
             }
         }
@@ -596,7 +596,7 @@ where
     f(&lhst, &rhst, span, ctx).map_err(|e| {
         TypeCheckError::new(
             format!(
-                "Operation {op} between incompatible type {:?} and {:?}: {}",
+                "Operation {op} between incompatible type {} and {}: {}",
                 lhst, rhst, e.msg
             ),
             lhs.span,

--- a/parser/src/type_checker.rs
+++ b/parser/src/type_checker.rs
@@ -377,7 +377,7 @@ fn tc_coerce_type<'src>(
             }
             Array(
                 Box::new(tc_coerce_type(v_inner, t_inner, span, ctx)?),
-                *t_len,
+                t_len.clone(),
             )
         }
         (Float, Float) => Float,
@@ -439,7 +439,7 @@ fn tc_cast_type<'src>(
             // Array doesn't recursively type cast for performance reasons.
             Array(
                 Box::new(tc_coerce_type(v_inner, t_inner, span, ctx)?),
-                *t_len,
+                t_len.clone(),
             )
         }
         (I32 | I64 | F32 | F64 | Integer | Float, Float) => Float,

--- a/parser/src/type_checker.rs
+++ b/parser/src/type_checker.rs
@@ -370,6 +370,16 @@ fn tc_coerce_type<'src>(
                         ));
                     }
                 }
+                (ArraySize::Range(v_range), ArraySize::Range(t_range)) => {
+                    if t_range.end < v_range.end || v_range.start < t_range.start {
+                        return Err(TypeCheckError::new(format!("Array range is not compatible: {v_range:?} cannot assign to {t_range:?}"), span, ctx.source_file));
+                    }
+                }
+                (ArraySize::Fixed(v_len), ArraySize::Range(t_range)) => {
+                    if *v_len < t_range.start || t_range.end < *v_len {
+                        return Err(TypeCheckError::new(format!("Array range is not compatible: {v_len} cannot assign to {t_range:?}"), span, ctx.source_file));
+                    }
+                }
                 (ArraySize::Dynamic | ArraySize::Any, ArraySize::Dynamic) => {}
                 _ => {
                     return Err(TypeCheckError::new(format!("Array size constraint is not compatible between {v_len:?} and {t_len:?}"), span, ctx.source_file));

--- a/parser/src/type_checker.rs
+++ b/parser/src/type_checker.rs
@@ -643,7 +643,7 @@ fn binary_op_type<'src>(
         (Integer, I64) | (I64, Integer) => I64,
         (Integer, I32) | (I32, Integer) => I32,
         (Array(lhs, lhs_len), Array(rhs, rhs_len)) => {
-            tc_array_size(lhs_len, rhs_len)
+            tc_array_size(rhs_len, lhs_len)
                 .map_err(|e| TypeCheckError::new(e, span, ctx.source_file))?;
             if let Some((lhs_len, rhs_len)) = lhs_len.zip(rhs_len) {
                 if lhs_len < rhs_len {
@@ -704,8 +704,13 @@ fn binary_cmp_type<'src>(
         (Float, F64 | F32) | (F64 | F32, Float) => I32,
         (Integer, I64 | I32) | (I64 | I32, Integer) => I32,
         (Array(lhs, lhs_len), Array(rhs, rhs_len)) => {
-            tc_array_size(lhs_len, rhs_len)
-                .map_err(|e| TypeCheckError::new(e, span, ctx.source_file))?;
+            if lhs_len != rhs_len {
+                return Err(TypeCheckError::new(
+                    "Array size must be the same for comparison".to_string(),
+                    span,
+                    ctx.source_file,
+                ));
+            }
             return binary_cmp_type(lhs, rhs, span, ctx);
         }
         _ => {

--- a/parser/src/type_checker/test.rs
+++ b/parser/src/type_checker/test.rs
@@ -75,7 +75,7 @@ fn test_array_range_shorter_err() {
     assert_eq!(
         res,
         Err(TypeCheckError::new(
-            "Array range is not compatible: 4 cannot assign to 0..3".to_string(),
+            "Array range is not compatible: 4 cannot assign to ..3".to_string(),
             span.subslice(20, 12),
             None
         ))
@@ -90,7 +90,7 @@ fn test_array_range_longer_err() {
     assert_eq!(
         res,
         Err(TypeCheckError::new(
-            "Array range is not compatible: 2 cannot assign to 3..18446744073709551615".to_string(),
+            "Array range is not compatible: 2 cannot assign to 3..".to_string(),
             span.subslice(20, 6),
             None
         ))

--- a/parser/src/type_checker/test.rs
+++ b/parser/src/type_checker/test.rs
@@ -46,3 +46,63 @@ fn test_tuple_index_err() {
         ))
     );
 }
+
+#[test]
+fn test_array_range_shorter() {
+    let span = Span::new(r#"var a: [i32; ..3] = [0, 1]; a[0]"#);
+    let (_, ast) = crate::parser::source(span).unwrap();
+    assert_eq!(
+        type_check(&ast, &mut TypeCheckContext::new(None)).unwrap(),
+        TypeDecl::I32
+    );
+}
+
+#[test]
+fn test_array_range_longer() {
+    let span = Span::new(r#"var a: [i32; 3..] = [0, 1, 2, 3]; a[0]"#);
+    let (_, ast) = crate::parser::source(span).unwrap();
+    assert_eq!(
+        type_check(&ast, &mut TypeCheckContext::new(None)).unwrap(),
+        TypeDecl::I32
+    );
+}
+
+#[test]
+fn test_array_range_shorter_err() {
+    let span = Span::new(r#"var a: [i32; ..3] = [0, 1, 2, 3];"#);
+    let (_, ast) = crate::parser::source(span).unwrap();
+    let res = type_check(&ast, &mut TypeCheckContext::new(None));
+    assert_eq!(
+        res,
+        Err(TypeCheckError::new(
+            "Array range is not compatible: 4 cannot assign to 0..3".to_string(),
+            span.subslice(20, 12),
+            None
+        ))
+    );
+}
+
+#[test]
+fn test_array_range_longer_err() {
+    let span = Span::new(r#"var a: [i32; 3..] = [0, 1];"#);
+    let (_, ast) = crate::parser::source(span).unwrap();
+    let res = type_check(&ast, &mut TypeCheckContext::new(None));
+    assert_eq!(
+        res,
+        Err(TypeCheckError::new(
+            "Array range is not compatible: 2 cannot assign to 3..18446744073709551615".to_string(),
+            span.subslice(20, 6),
+            None
+        ))
+    );
+}
+
+#[test]
+fn test_array_range_full() {
+    let span = Span::new(r#"var a: [i32; ..] = [0, 1, 2, 3]; a[0]"#);
+    let (_, ast) = crate::parser::source(span).unwrap();
+    assert_eq!(
+        type_check(&ast, &mut TypeCheckContext::new(None)).unwrap(),
+        TypeDecl::I32
+    );
+}

--- a/parser/src/type_decl.rs
+++ b/parser/src/type_decl.rs
@@ -118,7 +118,6 @@ impl std::fmt::Display for TypeDecl {
             TypeDecl::Str => write!(f, "str")?,
             TypeDecl::Array(inner, len) => match len {
                 ArraySize::Any => write!(f, "[{}]", inner.to_string())?,
-                ArraySize::Dynamic => write!(f, "[{}; _]", inner.to_string())?,
                 ArraySize::Fixed(len) => write!(f, "[{}; {}]", inner.to_string(), len)?,
                 ArraySize::Range(r) => write!(f, "[{}; {:?}]", inner.to_string(), r)?,
             },

--- a/parser/src/type_decl.rs
+++ b/parser/src/type_decl.rs
@@ -118,8 +118,7 @@ impl std::fmt::Display for TypeDecl {
             TypeDecl::Str => write!(f, "str")?,
             TypeDecl::Array(inner, len) => match len {
                 ArraySize::Any => write!(f, "[{}]", inner.to_string())?,
-                ArraySize::Fixed(len) => write!(f, "[{}; {}]", inner.to_string(), len)?,
-                ArraySize::Range(r) => write!(f, "[{}; {:?}]", inner.to_string(), r)?,
+                _ => write!(f, "[{}; {}]", inner.to_string(), len)?,
             },
             TypeDecl::Float => write!(f, "<Float>")?,
             TypeDecl::Integer => write!(f, "<Integer>")?,

--- a/parser/src/type_decl.rs
+++ b/parser/src/type_decl.rs
@@ -116,10 +116,11 @@ impl std::fmt::Display for TypeDecl {
             TypeDecl::I64 => write!(f, "i64")?,
             TypeDecl::I32 => write!(f, "i32")?,
             TypeDecl::Str => write!(f, "str")?,
-            TypeDecl::Array(inner, len) => match *len {
+            TypeDecl::Array(inner, len) => match len {
                 ArraySize::Any => write!(f, "[{}]", inner.to_string())?,
                 ArraySize::Dynamic => write!(f, "[{}; _]", inner.to_string())?,
                 ArraySize::Fixed(len) => write!(f, "[{}; {}]", inner.to_string(), len)?,
+                ArraySize::Range(r) => write!(f, "[{}; {:?}]", inner.to_string(), r)?,
             },
             TypeDecl::Float => write!(f, "<Float>")?,
             TypeDecl::Integer => write!(f, "<Integer>")?,

--- a/parser/src/type_decl.rs
+++ b/parser/src/type_decl.rs
@@ -135,6 +135,7 @@ impl std::fmt::Display for TypeDecl {
     }
 }
 
+#[allow(dead_code)]
 fn write_opt_usize(value: &Option<usize>, writer: &mut impl Write) -> std::io::Result<()> {
     write_bool(value.is_some(), writer)?;
     if let Some(value) = value {
@@ -143,6 +144,7 @@ fn write_opt_usize(value: &Option<usize>, writer: &mut impl Write) -> std::io::R
     Ok(())
 }
 
+#[allow(dead_code)]
 fn read_opt_usize(reader: &mut impl Read) -> Result<Option<usize>, ReadError> {
     let has_value = read_bool(reader)?;
     Ok(if has_value {

--- a/parser/src/type_decl.rs
+++ b/parser/src/type_decl.rs
@@ -1,6 +1,10 @@
 use std::io::{Read, Write};
 
-use crate::{type_tags::*, Value};
+use crate::{
+    bytecode::{read_bool, write_bool},
+    type_tags::*,
+    ReadError, Value,
+};
 
 #[derive(Debug, PartialEq, Clone)]
 #[repr(u8)]
@@ -11,7 +15,7 @@ pub enum TypeDecl {
     I64,
     I32,
     Str,
-    Array(Box<TypeDecl>),
+    Array(Box<TypeDecl>, Option<usize>),
     /// An abstract type that can match F64 or F32
     Float,
     /// An abstract type that can match I64 or I32
@@ -27,7 +31,7 @@ impl TypeDecl {
             Value::I32(_) => Self::I32,
             Value::I64(_) => Self::I64,
             Value::Str(_) => Self::Str,
-            Value::Array(a) => Self::Array(Box::new(a.borrow().type_decl.clone())),
+            Value::Array(a) => Self::Array(Box::new(a.borrow().type_decl.clone()), None),
             Value::Ref(a) => Self::from_value(&*a.borrow()),
             Value::ArrayRef(a, _) => a.borrow().type_decl.clone(),
             Value::Tuple(a) => Self::Tuple(
@@ -47,8 +51,9 @@ impl TypeDecl {
             Self::I64 => I64_TAG,
             Self::I32 => I32_TAG,
             Self::Str => STR_TAG,
-            Self::Array(inner) => {
+            Self::Array(inner, len) => {
                 writer.write_all(&ARRAY_TAG.to_le_bytes())?;
+                write_opt_usize(len, writer)?;
                 inner.serialize(writer)?;
                 return Ok(());
             }
@@ -83,7 +88,13 @@ impl TypeDecl {
             I64_TAG => Self::I64,
             I32_TAG => Self::I32,
             STR_TAG => Self::Str,
-            ARRAY_TAG => Self::Array(Box::new(Self::deserialize(reader)?)),
+            ARRAY_TAG => Self::Array(
+                Box::new(Self::deserialize(reader)?),
+                read_opt_usize(reader).map_err(|e| {
+                    let ReadError::IO(e) = e else { panic!() };
+                    e
+                })?,
+            ),
             REF_TAG => todo!(),
             FLOAT_TAG => Self::Float,
             INTEGER_TAG => Self::Integer,
@@ -101,7 +112,13 @@ impl std::fmt::Display for TypeDecl {
             TypeDecl::I64 => write!(f, "i64")?,
             TypeDecl::I32 => write!(f, "i32")?,
             TypeDecl::Str => write!(f, "str")?,
-            TypeDecl::Array(inner) => write!(f, "[{}]", inner.to_string())?,
+            TypeDecl::Array(inner, len) => {
+                if let Some(len) = *len {
+                    write!(f, "[{}; {}]", inner.to_string(), len)?
+                } else {
+                    write!(f, "[{}]", inner.to_string())?
+                }
+            }
             TypeDecl::Float => write!(f, "<Float>")?,
             TypeDecl::Integer => write!(f, "<Integer>")?,
             TypeDecl::Tuple(inner) => write!(
@@ -114,4 +131,23 @@ impl std::fmt::Display for TypeDecl {
         }
         Ok(())
     }
+}
+
+fn write_opt_usize(value: &Option<usize>, writer: &mut impl Write) -> std::io::Result<()> {
+    write_bool(value.is_some(), writer)?;
+    if let Some(value) = value {
+        writer.write_all(&value.to_le_bytes())?;
+    }
+    Ok(())
+}
+
+fn read_opt_usize(reader: &mut impl Read) -> Result<Option<usize>, ReadError> {
+    let has_value = read_bool(reader)?;
+    Ok(if has_value {
+        let mut buf = [0u8; std::mem::size_of::<usize>()];
+        reader.read_exact(&mut buf)?;
+        Some(usize::from_le_bytes(buf))
+    } else {
+        None
+    })
 }

--- a/parser/src/type_decl.rs
+++ b/parser/src/type_decl.rs
@@ -1,3 +1,7 @@
+mod array_size;
+
+pub use self::array_size::ArraySize;
+use self::array_size::{read_array_size, write_array_size};
 use std::io::{Read, Write};
 
 use crate::{
@@ -147,71 +151,5 @@ fn read_opt_usize(reader: &mut impl Read) -> Result<Option<usize>, ReadError> {
         Some(usize::from_le_bytes(buf))
     } else {
         None
-    })
-}
-
-#[derive(Debug, PartialEq, Clone, Copy)]
-pub enum ArraySize {
-    /// Either dynamic or fixed array
-    Any,
-    /// Only dynamic array
-    Dynamic,
-    /// Fixed array with a length
-    Fixed(usize),
-}
-
-impl ArraySize {
-    fn tag(&self) -> u8 {
-        match self {
-            Self::Any => 0,
-            Self::Dynamic => 1,
-            Self::Fixed(_) => 2,
-        }
-    }
-
-    pub fn zip(&self, other: &Self) -> Option<(usize, usize)> {
-        match (self, other) {
-            (Self::Fixed(lhs), Self::Fixed(rhs)) => Some((*lhs, *rhs)),
-            _ => None,
-        }
-    }
-
-    pub fn ok(&self) -> Option<usize> {
-        match self {
-            Self::Fixed(len) => Some(*len),
-            _ => None,
-        }
-    }
-
-    pub fn or(&self, other: &Self) -> Self {
-        match (self, other) {
-            (Self::Fixed(lhs), _) => Self::Fixed(*lhs),
-            (_, Self::Fixed(rhs)) => Self::Fixed(*rhs),
-            (Self::Dynamic, Self::Dynamic) => Self::Dynamic,
-            _ => Self::Any,
-        }
-    }
-}
-
-fn write_array_size(value: &ArraySize, writer: &mut impl Write) -> std::io::Result<()> {
-    writer.write_all(&mut [value.tag()])?;
-    if let ArraySize::Fixed(value) = value {
-        writer.write_all(&value.to_le_bytes())?;
-    }
-    Ok(())
-}
-
-fn read_array_size(reader: &mut impl Read) -> Result<ArraySize, ReadError> {
-    let mut tag = [0u8; 1];
-    reader.read_exact(&mut tag)?;
-    Ok(match tag[0] {
-        0 => ArraySize::Any,
-        1 => ArraySize::Dynamic,
-        2 => {
-            let mut buf = [0u8; std::mem::size_of::<usize>()];
-            reader.read_exact(&mut buf)?;
-            ArraySize::Fixed(usize::from_le_bytes(buf))
-        }
-        _ => return Err(ReadError::UndefinedOpCode(tag[0])),
     })
 }

--- a/parser/src/type_decl/array_size.rs
+++ b/parser/src/type_decl/array_size.rs
@@ -2,7 +2,7 @@ use std::io::{Read, Write};
 
 use crate::ReadError;
 
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum ArraySize {
     /// Either dynamic or fixed array
     Any,
@@ -10,6 +10,7 @@ pub enum ArraySize {
     Dynamic,
     /// Fixed array with a length
     Fixed(usize),
+    Range(std::ops::Range<usize>),
 }
 
 impl ArraySize {
@@ -18,6 +19,7 @@ impl ArraySize {
             Self::Any => 0,
             Self::Dynamic => 1,
             Self::Fixed(_) => 2,
+            Self::Range(_) => 3,
         }
     }
 

--- a/parser/src/type_decl/array_size.rs
+++ b/parser/src/type_decl/array_size.rs
@@ -47,6 +47,21 @@ impl ArraySize {
     }
 }
 
+impl std::fmt::Display for ArraySize {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Any => write!(f, "_"),
+            Self::Fixed(v) => write!(f, "{v}"),
+            Self::Range(range) => match (range.start, range.end) {
+                (0, usize::MAX) => write!(f, ".."),
+                (start, usize::MAX) => write!(f, "{start}.."),
+                (0, end) => write!(f, "..{end}"),
+                (start, end) => write!(f, "{start}..{end}"),
+            },
+        }
+    }
+}
+
 pub(super) fn write_array_size(value: &ArraySize, writer: &mut impl Write) -> std::io::Result<()> {
     writer.write_all(&mut [value.tag()])?;
     match value {

--- a/parser/src/type_decl/array_size.rs
+++ b/parser/src/type_decl/array_size.rs
@@ -1,0 +1,69 @@
+use std::io::{Read, Write};
+
+use crate::ReadError;
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum ArraySize {
+    /// Either dynamic or fixed array
+    Any,
+    /// Only dynamic array
+    Dynamic,
+    /// Fixed array with a length
+    Fixed(usize),
+}
+
+impl ArraySize {
+    fn tag(&self) -> u8 {
+        match self {
+            Self::Any => 0,
+            Self::Dynamic => 1,
+            Self::Fixed(_) => 2,
+        }
+    }
+
+    pub fn zip(&self, other: &Self) -> Option<(usize, usize)> {
+        match (self, other) {
+            (Self::Fixed(lhs), Self::Fixed(rhs)) => Some((*lhs, *rhs)),
+            _ => None,
+        }
+    }
+
+    pub fn ok(&self) -> Option<usize> {
+        match self {
+            Self::Fixed(len) => Some(*len),
+            _ => None,
+        }
+    }
+
+    pub fn or(&self, other: &Self) -> Self {
+        match (self, other) {
+            (Self::Fixed(lhs), _) => Self::Fixed(*lhs),
+            (_, Self::Fixed(rhs)) => Self::Fixed(*rhs),
+            (Self::Dynamic, Self::Dynamic) => Self::Dynamic,
+            _ => Self::Any,
+        }
+    }
+}
+
+pub(super) fn write_array_size(value: &ArraySize, writer: &mut impl Write) -> std::io::Result<()> {
+    writer.write_all(&mut [value.tag()])?;
+    if let ArraySize::Fixed(value) = value {
+        writer.write_all(&value.to_le_bytes())?;
+    }
+    Ok(())
+}
+
+pub(super) fn read_array_size(reader: &mut impl Read) -> Result<ArraySize, ReadError> {
+    let mut tag = [0u8; 1];
+    reader.read_exact(&mut tag)?;
+    Ok(match tag[0] {
+        0 => ArraySize::Any,
+        1 => ArraySize::Dynamic,
+        2 => {
+            let mut buf = [0u8; std::mem::size_of::<usize>()];
+            reader.read_exact(&mut buf)?;
+            ArraySize::Fixed(usize::from_le_bytes(buf))
+        }
+        _ => return Err(ReadError::UndefinedOpCode(tag[0])),
+    })
+}

--- a/parser/src/value.rs
+++ b/parser/src/value.rs
@@ -244,7 +244,8 @@ impl Value {
         match self {
             Value::Ref(r) => r.borrow_mut().array_push(value),
             Value::Array(array) => {
-                array.borrow_mut().values.push(value.deref()?);
+                let mut array_int = array.borrow_mut();
+                array_int.values.push(value.deref()?);
                 Ok(())
             }
             _ => Err("push() must be called for an array".to_string().into()),

--- a/scripts/array_range_sized.dragon
+++ b/scripts/array_range_sized.dragon
@@ -4,7 +4,7 @@ var i: i32 = 0;
 // Pushing to a fixed size array is prohibited
 // push(a, a[0]);
 
-fn f(b: [i32; 3]) {
+fn f(b: [i32; 3..4]) {
     print(b, type(b));
 }
 

--- a/scripts/array_range_sized.dragon
+++ b/scripts/array_range_sized.dragon
@@ -1,6 +1,5 @@
 var a: [i32; 3] = [1,3,5];
-var alen: i64 = len(a);
-var i: i32 = 0;
+
 // Pushing to a fixed size array is prohibited
 // push(a, a[0]);
 
@@ -9,3 +8,11 @@ fn f(b: [i32; 3..4]) {
 }
 
 f(a);
+
+var a: [i32; ..] = [3, 2, 3];
+var b: [i32; 2..] = [2, 2, 2];
+var c: [i32; ..10] = [1, 2, 3];
+var d: [i32; 5..5] = [1, 2, 3, 4, 5];
+a = b;
+
+print(a);

--- a/scripts/array_sized.dragon
+++ b/scripts/array_sized.dragon
@@ -1,0 +1,10 @@
+var a: [i32; 3] = [1,3,5];
+var alen: i64 = len(a);
+var i: i32 = 0;
+push(a, a[0]);
+
+fn f(b: [i32; 4]) {
+    print(b, type(b));
+}
+
+f(a);

--- a/scripts/array_sized.dragon
+++ b/scripts/array_sized.dragon
@@ -1,6 +1,5 @@
 var a: [i32; 3] = [1,3,5];
-var alen: i64 = len(a);
-var i: i32 = 0;
+
 // Pushing to a fixed size array is prohibited
 // push(a, a[0]);
 

--- a/scripts/fn_named_arg.dragon
+++ b/scripts/fn_named_arg.dragon
@@ -28,3 +28,14 @@ fn digits(a: f64, b: f64) -> f64 {
 
 print(digits(a: 1. + 2., b: 5.));
 print(digits(b: 1. + 2., a: 5.));
+
+fn my_pow(base: f64 = 10., p: i64 = 2) -> f64 {
+    var ret = 1.;
+    for i in 0..p {
+        ret = ret * base;
+    }
+    ret;
+}
+
+print(my_pow(base: 10.));
+print(my_pow(p: 2));

--- a/wasm/js/main.js
+++ b/wasm/js/main.js
@@ -64,7 +64,8 @@ const samples = document.getElementById("samples");
 [
     "expr.dragon", "factorial.dragon", "fibonacci.dragon", "recurse.dragon", "mandel.dragon",
     "mandel_canvas.dragon", "str.dragon", "type.dragon", "sieve.dragon",
-    "if.dragon", "for.dragon", "fn.dragon", "array.dragon", "array_reverse.dragon", "canvas.dragon",
+    "if.dragon", "for.dragon", "fn.dragon", "array.dragon", "array_reverse.dragon", "array_range_sized.dragon",
+    "canvas.dragon",
     "typecheck.dragon", "cast.dragon", "cast_error.dragon",
 ]
     .forEach(fileName => {


### PR DESCRIPTION
Add support for sized arrays, e.g. `[i32; 3]` means an array of 3 `i32`s.

You can also declare an unsized array like `[i32]`, which means an array with any length can be assigned.

## Preventing assignments among arrays with different sizes

This will prevent a common mistake, For example, this code below will fail:

```
fn f(b: [i32; 3]) {
    print("first: ", b[0], ", second: ", b[1], ", third: ", b[2]);
}

f([1,3]);

```

with this error:

```
Type check error: Assignee array is smaller than assigner
```

because `f` is called with an array of length 2, but the function signature requires the argument to have length 3.

You can also declare a variable or a function parameter without a size, which means it can have any length:

```
fn f(b: [i32]) {
    if 2 < len(b) {
        print("first: ", b[0], ", second: ", b[1], ", third: ", b[2]);
    } else {
        print("array too short");
    };
}
```

In this case, the responsibility to ensure the array has at least the required length is on the function implementation.

## Checking argument to `push`

Another interesting consequence is that we can reject a code that attempts to modify the length of a fixed size array, e.g. the following code will be an error:

```
var a: [i32; 3] = [1,3,5];
push(a, 7);
```

With this message:

```
Type check error: Array size constraint is not compatible between Fixed(3) and Dynamic
```

because it would break the invariance that the array has a fixed size.

# Ranged array sizes

You can also declare array sizes with range expressions similar to Rust:

```
var a: [i32; ..] = [3, 2, 3]; // Any range
var b: [i32; 2..] = [2, 2, 2]; // 2 or larger
var c: [i32; ..10] = [1, 2, 3]; // 10 or less
var d: [i32; 3..5] = [1, 2, 3, 4, 5]; // between 3 and 5
```

Note that the "range expression" is not actually an expression, but a syntax specific inside array size.

You can assign a narrow type to wider type:

```
a = b;
```

but not the other way around:

```
b = a;
```

This is a step towards strongly typed array shapes.