### PR TITLE
Structural flow for instructions

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -72,6 +72,7 @@ fn main() -> Result<(), String> {
                     .map_err(|e| e.to_string())?;
             }
             if args.disasm {
+                cache_bytecode(&mut bytecode).map_err(|e| e.to_string())?;
                 bytecode
                     .disasm(&mut std::io::stdout())
                     .map_err(|e| e.to_string())?;
@@ -83,6 +84,7 @@ fn main() -> Result<(), String> {
             }
             if args.compile_and_run {
                 bytecode.add_std_fn();
+                cache_bytecode(&mut bytecode).map_err(|e| e.to_string())?;
                 interpret(&bytecode).map_err(|e| e.to_string())?;
             }
         } else {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -72,7 +72,7 @@ fn main() -> Result<(), String> {
                     .map_err(|e| e.to_string())?;
             }
             if args.disasm {
-                cache_bytecode(&mut bytecode).map_err(|e| e.to_string())?;
+                bytecode.cache_bytecode().map_err(|e| e.to_string())?;
                 bytecode
                     .disasm(&mut std::io::stdout())
                     .map_err(|e| e.to_string())?;
@@ -84,7 +84,7 @@ fn main() -> Result<(), String> {
             }
             if args.compile_and_run {
                 bytecode.add_std_fn();
-                cache_bytecode(&mut bytecode).map_err(|e| e.to_string())?;
+                bytecode.cache_bytecode().map_err(|e| e.to_string())?;
                 interpret(&bytecode).map_err(|e| e.to_string())?;
             }
         } else {

--- a/parser/src/bytecode.rs
+++ b/parser/src/bytecode.rs
@@ -323,6 +323,15 @@ impl Bytecode {
         }
         Ok(())
     }
+
+    pub fn cache_bytecode(&mut self) -> Result<(), EvalError> {
+        for (_, f) in self.functions.iter_mut() {
+            if let FnProto::Code(code) = f {
+                code.jump_map = cache_bytecode_fn(&code.instructions)?;
+            }
+        }
+        Ok(())
+    }
 }
 
 /// Add standard common functions, such as `print`, `len` and `push`, to this bytecode.
@@ -524,15 +533,6 @@ impl FnBytecode {
             .cloned()
             .ok_or_else(|| EvalError::MissingEnd)
     }
-}
-
-pub fn cache_bytecode(bytecode: &mut Bytecode) -> Result<(), EvalError> {
-    for (_, f) in bytecode.functions.iter_mut() {
-        if let FnProto::Code(code) = f {
-            code.jump_map = cache_bytecode_fn(&code.instructions)?;
-        }
-    }
-    Ok(())
 }
 
 fn cache_bytecode_fn(instructions: &[Instruction]) -> Result<JumpMap, EvalError> {

--- a/parser/src/bytecode.rs
+++ b/parser/src/bytecode.rs
@@ -122,6 +122,8 @@ impl_op_from!(
     Call,
     Ret,
     Cast,
+    If,
+    Else,
     Block,
     Loop,
     End

--- a/parser/src/bytecode.rs
+++ b/parser/src/bytecode.rs
@@ -65,6 +65,12 @@ pub enum OpCode {
     /// Casts a value at arg0 to a type indicated by arg1. I'm feeling this should be a standard library function
     /// rather than a opcode, but let's finish implementation compatible with AST interpreter first.
     Cast,
+    /// Marks the beginning of a block, in which jump instructions will jump to the end.
+    Block,
+    /// Marks the beginning of a loop, which is the destination instruction when a jump instruction is called.
+    Loop,
+    /// Marks the end of a control block.
+    End,
 }
 
 macro_rules! impl_op_from {
@@ -109,7 +115,10 @@ impl_op_from!(
     Jf,
     Call,
     Ret,
-    Cast
+    Cast,
+    Block,
+    Loop,
+    End
 );
 
 /// A single instruction in a bytecode. OpCodes can have 0 to 2 arguments.

--- a/parser/src/bytecode.rs
+++ b/parser/src/bytecode.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 /// Operational codes for an instruction. Supposed to fit in an u8.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 #[repr(u8)]
 pub enum OpCode {
     LoadLiteral,
@@ -74,6 +74,7 @@ pub enum OpCode {
     /// Marks the beginning of a loop, which is the destination instruction when a jump instruction is called.
     Loop,
     /// Marks the end of a control block.
+    #[default]
     End,
 }
 

--- a/parser/src/bytecode.rs
+++ b/parser/src/bytecode.rs
@@ -65,6 +65,10 @@ pub enum OpCode {
     /// Casts a value at arg0 to a type indicated by arg1. I'm feeling this should be a standard library function
     /// rather than a opcode, but let's finish implementation compatible with AST interpreter first.
     Cast,
+    /// Marks the beginning of a conditional block, should be followed by Else or End control flow instruction.
+    If,
+    /// Marks the beginning of an else block of a conditional block, should be followed by an End control flow instruction.
+    Else,
     /// Marks the beginning of a block, in which jump instructions will jump to the end.
     Block,
     /// Marks the beginning of a loop, which is the destination instruction when a jump instruction is called.

--- a/parser/src/compiler.rs
+++ b/parser/src/compiler.rs
@@ -350,7 +350,6 @@ fn emit_stmts<'src>(
                 // Form a double block to jump either forward or backward
                 compiler.push_loop();
                 compiler.push_block();
-                compiler.bytecode.push_inst(OpCode::Block, 0, 0);
                 let stk_cond = emit_expr(cond, compiler)?;
                 compiler.bytecode.push_inst(OpCode::Jf, stk_cond as u8, 1);
                 last_target = emit_stmts(stmts, compiler)?;

--- a/parser/src/compiler.rs
+++ b/parser/src/compiler.rs
@@ -76,6 +76,7 @@ impl<'a> Compiler<'a> {
                 args: fn_args,
                 instructions: vec![],
                 stack_size: 0,
+                jump_map: HashMap::new(),
             },
             target_stack: (0..args.len() + 1)
                 .map(|i| {

--- a/parser/src/compiler.rs
+++ b/parser/src/compiler.rs
@@ -401,7 +401,6 @@ fn emit_stmts<'src>(
                 compiler.pop_loop();
             }
             Statement::Break(span) => {
-                dbg!(&compiler.block_stack);
                 if let Some((nest_level, _)) = compiler
                     .block_stack
                     .iter()

--- a/parser/src/compiler.rs
+++ b/parser/src/compiler.rs
@@ -398,7 +398,7 @@ fn emit_stmts<'src>(
                 compiler.bytecode.push_inst(OpCode::End, 0, 0); // End Block
                 compiler.bytecode.push_inst(OpCode::End, 0, 0); // End Loop
             }
-            Statement::Break => {
+            Statement::Break(span) => {
                 dbg!(&compiler.block_stack);
                 if let Some((nest_level, _)) = compiler
                     .block_stack
@@ -411,7 +411,7 @@ fn emit_stmts<'src>(
                         .bytecode
                         .push_inst(OpCode::Jmp, 0, (nest_level + 1) as u16);
                 } else {
-                    return Err(CompileError::new_nospan(CEK::DisallowedBreak));
+                    return Err(CompileError::new(*span, CEK::DisallowedBreak));
                 }
             }
             Statement::Comment(_) => (),

--- a/parser/src/compiler.rs
+++ b/parser/src/compiler.rs
@@ -347,14 +347,15 @@ fn emit_stmts<'src>(
             }
             Statement::While(cond, stmts) => {
                 // Form a double block to jump either forward or backward
-                compiler.bytecode.push_inst(OpCode::Loop, 0, 0);
+                compiler.push_loop();
+                compiler.push_block();
                 compiler.bytecode.push_inst(OpCode::Block, 0, 0);
                 let stk_cond = emit_expr(cond, compiler)?;
                 compiler.bytecode.push_inst(OpCode::Jf, stk_cond as u8, 1);
                 last_target = emit_stmts(stmts, compiler)?;
                 compiler.bytecode.push_inst(OpCode::Jmp, 0, 2);
-                compiler.bytecode.push_inst(OpCode::End, 0, 0); // End Block
-                compiler.bytecode.push_inst(OpCode::End, 0, 0); // End Loop
+                compiler.pop_block();
+                compiler.pop_loop();
             }
             Statement::For(iter, from, to, stmts) => {
                 let stk_from = emit_expr(from, compiler)?;

--- a/parser/src/compiler.rs
+++ b/parser/src/compiler.rs
@@ -351,7 +351,7 @@ fn emit_stmts<'src>(
                 //         stk_to is the end value
                 //     and stk_check is the value to store the result of comparison
 
-                let inst_loop_start = compiler.bytecode.instructions.len();
+                compiler.bytecode.instructions.len();
                 compiler
                     .locals
                     .last_mut()
@@ -362,20 +362,21 @@ fn emit_stmts<'src>(
                     });
                 compiler.target_stack[stk_from] = Target::Local(local_iter);
                 compiler.target_stack.push(Target::None);
+                // Form a double block to jump either forward or backward
+                compiler.bytecode.push_inst(OpCode::Loop, 0, 0);
+                compiler.bytecode.push_inst(OpCode::Block, 0, 0);
                 compiler
                     .bytecode
                     .push_inst(OpCode::Move, stk_from as u8, stk_check as u16);
                 compiler
                     .bytecode
                     .push_inst(OpCode::Lt, stk_check as u8, stk_to as u16);
-                let inst_break = compiler.bytecode.push_inst(OpCode::Jf, stk_check as u8, 0);
+                compiler.bytecode.push_inst(OpCode::Jf, stk_check as u8, 1);
                 last_target = emit_stmts(stmts, compiler)?;
                 compiler.bytecode.push_inst(OpCode::Incr, stk_from as u8, 0);
-                compiler
-                    .bytecode
-                    .push_inst(OpCode::Jmp, 0, inst_loop_start as u16);
-                compiler.bytecode.instructions[inst_break].arg1 =
-                    compiler.bytecode.instructions.len() as u16;
+                compiler.bytecode.push_inst(OpCode::Jmp, 0, 2);
+                compiler.bytecode.push_inst(OpCode::End, 0, 0); // End Block
+                compiler.bytecode.push_inst(OpCode::End, 0, 0); // End Loop
                 compiler.fixup_breaks();
             }
             Statement::Break => {

--- a/parser/src/compiler.rs
+++ b/parser/src/compiler.rs
@@ -381,7 +381,7 @@ fn emit_stmts<'src>(
             }
             Statement::Break => {
                 let break_ip = compiler.bytecode.instructions.len();
-                compiler.bytecode.push_inst(OpCode::Jmp, 0, 0);
+                compiler.bytecode.push_inst(OpCode::Jmp, 0, 1);
                 compiler.break_ips.push(break_ip);
             }
             Statement::Comment(_) => (),

--- a/parser/src/compiler.rs
+++ b/parser/src/compiler.rs
@@ -383,8 +383,8 @@ fn emit_stmts<'src>(
                 compiler.target_stack[stk_from] = Target::Local(local_iter);
                 compiler.target_stack.push(Target::None);
                 // Form a double block to jump either forward or backward
-                compiler.bytecode.push_inst(OpCode::Loop, 0, 0);
-                compiler.bytecode.push_inst(OpCode::Block, 0, 0);
+                compiler.push_loop();
+                compiler.push_block();
                 compiler
                     .bytecode
                     .push_inst(OpCode::Move, stk_from as u8, stk_check as u16);
@@ -395,8 +395,8 @@ fn emit_stmts<'src>(
                 last_target = emit_stmts(stmts, compiler)?;
                 compiler.bytecode.push_inst(OpCode::Incr, stk_from as u8, 0);
                 compiler.bytecode.push_inst(OpCode::Jmp, 0, 2);
-                compiler.bytecode.push_inst(OpCode::End, 0, 0); // End Block
-                compiler.bytecode.push_inst(OpCode::End, 0, 0); // End Loop
+                compiler.pop_block();
+                compiler.pop_loop();
             }
             Statement::Break(span) => {
                 dbg!(&compiler.block_stack);

--- a/parser/src/compiler/error.rs
+++ b/parser/src/compiler/error.rs
@@ -30,6 +30,10 @@ impl<'src> CompileError<'src> {
             kind,
         }
     }
+
+    pub fn new_nospan(kind: CompileErrorKind) -> Self {
+        Self { span: None, kind }
+    }
 }
 
 impl<'src> std::error::Error for CompileError<'src> {}

--- a/parser/src/interpreter.rs
+++ b/parser/src/interpreter.rs
@@ -56,72 +56,75 @@ pub enum EvalError {
     NonLValue(String),
     ElseWithoutIf,
     MissingEnd,
+    BlockStackUnderflow,
 }
 
 impl std::error::Error for EvalError {}
 
 impl std::fmt::Display for EvalError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use EvalError::*;
         match self {
-            Self::Other(e) => write!(f, "Unknown error: {e}"),
-            Self::CoerceError(from, to) => {
+            Other(e) => write!(f, "Unknown error: {e}"),
+            CoerceError(from, to) => {
                 write!(f, "Coercing from {from:?} to {to:?} is disallowed")
             }
-            Self::OpError(lhs, rhs) => {
+            OpError(lhs, rhs) => {
                 write!(f, "Unsupported operation between {lhs:?} and {rhs:?}")
             }
-            Self::CmpError(lhs, rhs) => {
+            CmpError(lhs, rhs) => {
                 write!(f, "Unsupported comparison between {lhs:?} and {rhs:?}",)
             }
-            Self::FloatOpError(lhs, rhs) => {
+            FloatOpError(lhs, rhs) => {
                 write!(f, "Unsupported float operation between {lhs:?} and {rhs:?}")
             }
-            Self::StrOpError(lhs, rhs) => write!(
+            StrOpError(lhs, rhs) => write!(
                 f,
                 "Unsupported string operation between {lhs:?} and {rhs:?}"
             ),
-            Self::DisallowedBreak => write!(f, "Break in array literal not supported"),
-            Self::VarNotFound(name) => write!(f, "Variable {name} not found in scope"),
-            Self::FnNotFound(name) => write!(f, "Function {name} not found in scope"),
-            Self::ArrayOutOfBounds(idx, len) => write!(
+            DisallowedBreak => write!(f, "Break in array literal not supported"),
+            VarNotFound(name) => write!(f, "Variable {name} not found in scope"),
+            FnNotFound(name) => write!(f, "Function {name} not found in scope"),
+            ArrayOutOfBounds(idx, len) => write!(
                 f,
                 "ArrayRef index out of range: {idx} is larger than array length {len}"
             ),
-            Self::TupleOutOfBounds(idx, len) => write!(
+            TupleOutOfBounds(idx, len) => write!(
                 f,
                 "Tuple index out of range: {idx} is larger than tuple length {len}"
             ),
-            Self::IndexNonArray => write!(f, "array index must be called for an array"),
-            Self::NeedRef(name) => write!(
+            IndexNonArray => write!(f, "array index must be called for an array"),
+            NeedRef(name) => write!(
                 f,
                 "We need variable reference on lhs to assign. Actually we got {name:?}"
             ),
-            Self::NoMatchingArg(arg, fun) => write!(
+            NoMatchingArg(arg, fun) => write!(
                 f,
                 "No matching named parameter \"{arg}\" is found in function \"{fun}\""
             ),
-            Self::MissingArg(arg) => write!(f, "No argument is given to \"{arg}\""),
-            Self::BreakInToplevel => write!(f, "break in function toplevel"),
-            Self::BreakInFnArg => write!(f, "Break in function argument is not supported yet!"),
-            Self::NonIntegerIndex => write!(f, "Subscript type should be integer types"),
-            Self::NonIntegerBitwise(val) => {
+            MissingArg(arg) => write!(f, "No argument is given to \"{arg}\""),
+            BreakInToplevel => write!(f, "break in function toplevel"),
+            BreakInFnArg => write!(f, "Break in function argument is not supported yet!"),
+            NonIntegerIndex => write!(f, "Subscript type should be integer types"),
+            NonIntegerBitwise(val) => {
                 write!(f, "Bitwise operation is not supported for {val}")
             }
-            Self::NoMainFound => write!(f, "No main function found"),
-            Self::NonNameFnRef(val) => write!(
+            NoMainFound => write!(f, "No main function found"),
+            NonNameFnRef(val) => write!(
                 f,
                 "Function can be only specified by a name (yet), but got {val}"
             ),
-            Self::CallStackUndeflow => write!(f, "Call stack underflow!"),
-            Self::IncompatibleArrayLength(dst, src) => write!(
+            CallStackUndeflow => write!(f, "Call stack underflow!"),
+            IncompatibleArrayLength(dst, src) => write!(
                 f,
                 "Array length is incompatible; tried to assign {src} to {dst}"
             ),
-            Self::AssignToLiteral(name) => write!(f, "Cannot assign to a literal: {}", name),
-            Self::IndexNonNum => write!(f, "Indexed an array with a non-number"),
-            Self::NonLValue(ex) => write!(f, "Expression {} is not an lvalue.", ex),
-            Self::ElseWithoutIf => write!(f, "Else instruction showed up without corresponding if"),
-            Self::MissingEnd => write!(f, "Missing expected End instruction"),
+            AssignToLiteral(name) => write!(f, "Cannot assign to a literal: {}", name),
+            IndexNonNum => write!(f, "Indexed an array with a non-number"),
+            NonLValue(ex) => write!(f, "Expression {} is not an lvalue.", ex),
+            ElseWithoutIf => write!(f, "Else instruction showed up without corresponding if"),
+            MissingEnd => write!(f, "Missing expected End instruction"),
+            BlockStackUnderflow => write!(f, "Block stack underflow"),
         }
     }
 }

--- a/parser/src/interpreter.rs
+++ b/parser/src/interpreter.rs
@@ -54,6 +54,8 @@ pub enum EvalError {
     AssignToLiteral(String),
     IndexNonNum,
     NonLValue(String),
+    ElseWithoutIf,
+    MissingEnd,
 }
 
 impl std::error::Error for EvalError {}
@@ -118,6 +120,8 @@ impl std::fmt::Display for EvalError {
             Self::AssignToLiteral(name) => write!(f, "Cannot assign to a literal: {}", name),
             Self::IndexNonNum => write!(f, "Indexed an array with a non-number"),
             Self::NonLValue(ex) => write!(f, "Expression {} is not an lvalue.", ex),
+            Self::ElseWithoutIf => write!(f, "Else instruction showed up without corresponding if"),
+            Self::MissingEnd => write!(f, "Missing expected End instruction"),
         }
     }
 }

--- a/parser/src/interpreter.rs
+++ b/parser/src/interpreter.rs
@@ -1037,7 +1037,7 @@ where
                     res = RunResult::Yield(unwrap_break!(run(e, ctx)?));
                 }
             }
-            Statement::Break => {
+            Statement::Break(_) => {
                 return Ok(RunResult::Break);
             }
             _ => {}

--- a/parser/src/interpreter/test.rs
+++ b/parser/src/interpreter/test.rs
@@ -906,7 +906,7 @@ fn loop_test() {
                     ),
                     span.subslice(3, 7)
                 )),
-                vec![Statement::Break],
+                vec![Statement::Break(span.subslice("if i < 10 { ".len(), 6))],
                 None,
             ),
             span.subslice(0, 19)
@@ -947,7 +947,7 @@ fn loop_test() {
                             ),
                             span.subslice(36, 7)
                         )),
-                        vec![Statement::Break],
+                        vec![Statement::Break(span.subslice(45, 6))],
                         None
                     ),
                     span.subslice(33, 19)

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -15,7 +15,7 @@ mod type_tags;
 mod value;
 mod vm;
 
-pub use self::bytecode::{Bytecode, Instruction, OpCode};
+pub use self::bytecode::{cache_bytecode, Bytecode, Instruction, OpCode};
 pub use self::compiler::*;
 pub use self::interpreter::{coerce_type, run, EvalContext, EvalError, FuncDef};
 pub use self::parser::{span_source as source, ArgDecl, ReadError, Span};

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -15,7 +15,7 @@ mod type_tags;
 mod value;
 mod vm;
 
-pub use self::bytecode::{cache_bytecode, Bytecode, Instruction, OpCode};
+pub use self::bytecode::{Bytecode, Instruction, OpCode};
 pub use self::compiler::*;
 pub use self::interpreter::{coerce_type, run, EvalContext, EvalError, FuncDef};
 pub use self::parser::{span_source as source, ArgDecl, ReadError, Span};

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -1,6 +1,6 @@
 use crate::{
     type_decl::{ArraySize, TypeDecl},
-    Value,
+    EvalError, Value,
 };
 
 use nom::{
@@ -26,6 +26,7 @@ pub enum ReadError {
     FromUtf8(FromUtf8Error),
     NoMainFound,
     UndefinedOpCode(u8),
+    EvalError(EvalError),
 }
 
 impl From<std::io::Error> for ReadError {
@@ -40,16 +41,25 @@ impl From<FromUtf8Error> for ReadError {
     }
 }
 
+impl From<EvalError> for ReadError {
+    fn from(value: EvalError) -> Self {
+        Self::EvalError(value)
+    }
+}
+
 impl std::fmt::Display for ReadError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ReadError::IO(e) => write!(f, "{e}"),
-            ReadError::FromUtf8(e) => write!(f, "{e}"),
-            ReadError::NoMainFound => write!(f, "No main function found"),
-            ReadError::UndefinedOpCode(code) => write!(f, "Opcode \"{code:02X}\" unrecognized!"),
+            Self::IO(e) => write!(f, "{e}"),
+            Self::FromUtf8(e) => write!(f, "{e}"),
+            Self::NoMainFound => write!(f, "No main function found"),
+            Self::UndefinedOpCode(code) => write!(f, "Opcode \"{code:02X}\" unrecognized!"),
+            Self::EvalError(e) => e.fmt(f),
         }
     }
 }
+
+impl std::error::Error for ReadError {}
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct ArgDecl<'a> {

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -82,7 +82,7 @@ pub enum Statement<'a> {
     Loop(Vec<Statement<'a>>),
     While(Expression<'a>, Vec<Statement<'a>>),
     For(Span<'a>, Expression<'a>, Expression<'a>, Vec<Statement<'a>>),
-    Break,
+    Break(Span<'a>),
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -782,7 +782,7 @@ fn for_stmt(input: Span) -> IResult<Span, Statement> {
 
 fn break_stmt(input: Span) -> IResult<Span, Statement> {
     let (r, _) = ws(tag("break"))(input)?;
-    Ok((r, Statement::Break))
+    Ok((r, Statement::Break(calc_offset(input, r))))
 }
 
 fn general_statement<'a>(last: bool) -> impl Fn(Span<'a>) -> IResult<Span<'a>, Statement> {

--- a/parser/src/type_checker.rs
+++ b/parser/src/type_checker.rs
@@ -566,7 +566,7 @@ where
                 ctx.variables.insert(iter, TypeDecl::I64);
                 res = type_check(e, ctx)?;
             }
-            Statement::Break => {
+            Statement::Break(_) => {
                 // TODO: check types in break out site. For now we disallow break with values like Rust.
             }
             Statement::Comment(_) => (),

--- a/parser/src/vm.rs
+++ b/parser/src/vm.rs
@@ -469,20 +469,20 @@ fn interpret_fn(
 /// The destination address is calculated from block stack (structural control flow), so that there is
 /// no absolute instruction address in the bytecode to fixup.
 fn jump_inst(
-    name: &str,
+    _name: &str,
     inst: &Instruction,
     ip: usize,
     call_stack: &mut Vec<CallInfo>,
     vm: &mut Vm,
 ) -> EvalResult<()> {
-    dbg_println!("[{ip}] Jumping by {name} to block: {}", inst.arg1);
+    dbg_println!("[{ip}] Jumping by {_name} to block: {}", inst.arg1);
     let block_offset = inst.arg1 as usize;
     if vm.block_stack.len() < block_offset {
         return Err(EvalError::Other("Block stack underflow".to_string()));
     }
     let block = &vm.block_stack[vm.block_stack.len() - block_offset];
     if matches!(block.0, OpCode::Loop) {
-        dbg_println!("{name} is a backward jump ip: {}", block.1);
+        dbg_println!("{_name} is a backward jump ip: {}", block.1);
         call_stack.clast_mut()?.ip = block.1;
         vm.block_stack
             .resize(vm.block_stack.len() - block_offset, (OpCode::End, 0));
@@ -491,7 +491,7 @@ fn jump_inst(
     let ci = call_stack.clast()?;
     // TODO: precache forward jump map in the function since it will repeat many times in a loop.
     let jump_ip = ci.fun.find_jump(ip)?;
-    dbg_println!("{name} found a forward jump ip: {jump_ip}");
+    dbg_println!("{_name} found a forward jump ip: {jump_ip}");
     call_stack.clast_mut()?.ip = jump_ip + 1;
     vm.block_stack
         .resize(vm.block_stack.len() - block_offset, (OpCode::End, 0));

--- a/parser/src/vm.rs
+++ b/parser/src/vm.rs
@@ -406,7 +406,6 @@ fn jump_inst(
 ) -> EvalResult<()> {
     dbg_println!("[{ip}] Jumping by {_name} to block: {}", inst.arg1);
     let ci = call_stack.clast()?;
-    // TODO: precache forward jump map in the function since it will repeat many times in a loop.
     let jump_ip = ci.fun.find_jump(ip)?;
     dbg_println!("{_name} found a forward jump ip: {jump_ip}");
     call_stack.clast_mut()?.ip = jump_ip + 1;

--- a/parser/src/vm.rs
+++ b/parser/src/vm.rs
@@ -421,7 +421,10 @@ fn interpret_fn(
                 if !matches!(last.0, OpCode::If) {
                     return Err(EvalError::ElseWithoutIf);
                 }
-                *last = (OpCode::Else, ip);
+                let jump_ip = find_end(1, ip + 1, ci).ok_or_else(|| EvalError::MissingEnd)?;
+                dbg_println!("Else forward jump ip: {jump_ip}");
+                call_stack.clast_mut()?.ip = jump_ip + 1;
+                continue;
             }
             OpCode::Block | OpCode::Loop => {
                 vm.block_stack.push((inst.op, ip));

--- a/parser/src/vm/test.rs
+++ b/parser/src/vm/test.rs
@@ -40,7 +40,9 @@ fn parens_eval_test() {
 }
 
 fn compile_and_run(src: &str) -> Result<Value, EvalError> {
-    interpret(&compile(&span_source(src).unwrap().1, HashMap::new()).unwrap())
+    let mut code = compile(&span_source(src).unwrap().1, HashMap::new()).unwrap();
+    code.cache_bytecode()?;
+    interpret(&code)
 }
 
 #[test]
@@ -133,6 +135,7 @@ fn compile_and_run_with(src: &str, fun: impl Fn(&[Value]) + 'static) -> Result<V
             Ok(Value::I64(0))
         }),
     );
+    bytecode.cache_bytecode()?;
     interpret(&bytecode)
 }
 
@@ -167,7 +170,7 @@ fn define_func() {
 
 #[test]
 fn factorial() {
-    let res = compile_and_run_with(
+    compile_and_run_with(
         r#"
 fn fact(n) {
     if n < 1 {
@@ -180,8 +183,8 @@ fn fact(n) {
 print(fact(10));
 "#,
         |vals| assert_eq!(vals[0], Value::I64(3628800)),
-    );
-    assert!(res.is_ok());
+    )
+    .unwrap();
 }
 
 #[test]
@@ -221,7 +224,7 @@ print(res);
 
 #[test]
 fn while_test() {
-    let res = compile_and_run_with(
+    compile_and_run_with(
         r#"var i = 0;
 
 while i < 10 {
@@ -231,8 +234,8 @@ while i < 10 {
 print(i);
 "#,
         |vals| assert_eq!(vals[0], Value::I64(10)),
-    );
-    assert!(res.is_ok());
+    )
+    .unwrap();
 }
 
 #[test]

--- a/scripts/for.dragon
+++ b/scripts/for.dragon
@@ -1,9 +1,6 @@
 
-for i in 0..10 {
-    print(i * i);
-}
-
-
-for i in 0 .. 10 {
-    print(0 - i * i);
+for i in 0..3 {
+    for j in 1..3 {
+        print(i * j);
+    }
 }

--- a/scripts/recurse_for.dragon
+++ b/scripts/recurse_for.dragon
@@ -1,0 +1,18 @@
+
+fn rec(n) {
+    if 0 < n {
+        rec(n - 1) + 1;
+    } else {
+        0;
+    }
+}
+
+fn print_sum(n) {
+    for i in 0..n {
+        print(i, rec(i));
+    }
+}
+
+if 1 {
+    print_sum(3);
+}

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -192,6 +192,7 @@ pub fn compile_and_run(src: &str) -> Result<(), JsValue> {
     let mut bytecode = mascal::compile(&parse_result.1, functions)
         .map_err(|e| JsValue::from_str(&format!("Error: {}", e)))?;
     bytecode.add_std_fn();
+    bytecode.cache_bytecode();
     extra_functions(&mut |name, f| {
         bytecode.add_ext_fn(name, f);
     });


### PR DESCRIPTION
# Background

In WebAssembly, jump instruction does not contain explicit address, which makes the compiler much easier to implement, because it does not have to "fixup" the jump address if it is jumping forward.
The work of calculating the destination address is responsibility of the runtime virtual machine.
This design is a necessity rather than a preference since Wasm uses variable length encoding for integers, calculating offset later would shift a whole chunk of instructions.

Another reason Wasm uses structured control flow is the safety. It won't break predictable behavior by jumping to a random address by a bug in bytecode, since the jump address is determined by the structure. The address is inferred by the block nesting level, which is easily verified by checking if it's less than the block stack size.

Also, structured control flow is much easier to read and reason about. Jump addresses are harder to understand and debug, since the information of control structure is lost by compiling from AST to bytecode.

I like this design so much so that I steal the idea of structural control flow. Now it looks like a hybrid of higher level language and assembly.

# structural flow instructions

We have following new "instructions" with quotes, because they are not found in real CPUs.

```rust
enum OpCode {
    // ...
    /// Marks the beginning of a conditional block, should be followed by Else or End control flow instruction.
    If,
    /// Marks the beginning of an else block of a conditional block, should be followed by an End control flow instruction.
    Else,
    /// Marks the beginning of a block, in which jump instructions will jump to the end.
    Block,
    /// Marks the beginning of a loop, which is the destination instruction when a jump instruction is called.
    Loop,
    /// Marks the end of a control block.
    #[default]
    End,
}
```

The stack for control blocks, pushed each time by Block or Loop instruction and popped by End.
Jump instructions jump forward in Block and back in Loop.

We follow the WebAssembly VM model, where loops and branches are implemented as blocks (structured control flow).
The block can be one of the following:

* Block (jump forward)

     Block
         ...
     End

* Loop (jump backward)

     Loop
         ...
     End

* If (skip forward conditionally)

     If
         ...
     End

* If/Else (skip to else clause conditionally)

     If
         ...
     Else
         ...
     End

Any jump instructions (`Jmp`, `Jt` and `Jf`) in these blocks will transfer the control flow to a new address, either the beginning of a block (`Loop`) or end (all the other instructions).

## Compiler generated code

In practice, `Block` and `Loop` will always come in pairs. If you compile a `for`, `loop` or `while` loop, the instructions would look like this:

    Loop
      Block
        ...
      End
    End

The inner part is the body of the loop control structure. `Jmp _ 1` will jump to the end of the block, meaning escaping the loop, making `break`. `Jmp _ 2` will jump to the beginning of the loop, making `continue` flow.


# Disassembly improvement

Now the disassembly is much more ergonomic. It shows the control flow structure by indentation.

```
Instructions(28):
  [  0] LoadLiteral 0 1 (I64(0))
  [  1] LoadLiteral 1 2 (I64(3))
  [  2] Loop 0 0
  [  3]   Block 0 0
  [  4]     Move 1 3
  [  5]     Lt 3 2
  [  6]     Jf 3 1
  [  7]     LoadLiteral 2 4 (I64(1))
  [  8]     LoadLiteral 1 5 (I64(3))
  [  9]     Loop 0 0
  [ 10]       Block 0 0
  [ 11]         Move 4 6
  [ 12]         Lt 6 5
  [ 13]         Jf 6 1
  [ 14]         Move 1 7
  [ 15]         Mul 7 4
  [ 16]         LoadLiteral 3 8 (Str("print"))
  [ 17]         Move 7 9
  [ 18]         Call 1 8
  [ 19]         Incr 4 0
  [ 20]         Jmp 0 2
  [ 21]       End 0 0
  [ 22]     End 0 0
  [ 23]     Incr 1 0
  [ 24]     Jmp 0 2
  [ 25]   End 0 0
  [ 26] End 0 0
  [ 27] Ret 0 8
```

It was like this before.

```
Instructions(20):
  [0] LoadLiteral 0 1 (I64(0))
  [1] LoadLiteral 1 2 (I64(3))
  [2] Move 1 3
  [3] Lt 3 2
  [4] Jf 3 19
  [5] LoadLiteral 2 4 (I64(1))
  [6] LoadLiteral 1 5 (I64(3))
  [7] Move 4 6
  [8] Lt 6 5
  [9] Jf 6 17
  [10] Move 1 7
  [11] Mul 7 4
  [12] LoadLiteral 3 8 (Str("print"))
  [13] Move 7 9
  [14] Call 1 8
  [15] Incr 4 0
  [16] Jmp 0 7
  [17] Incr 1 0
  [18] Jmp 0 2
  [19] Ret 0 8
```


# Benchmark

Since structural flow puts the burden of calculating jump address to the bytecode interpreter, we would like to know how much is the impact on perfoamnce.
Here is the latest measurement of Mandelbrot set ascii art rendering time among other languages. Error bars are standard deviation of 5 runs.

![mandel-time](https://github.com/user-attachments/assets/5f2fe661-3a6c-4466-95a3-fa515f7e8bd5)

The ones relevant are named Mascal.

* Mascal AST interpreter - an interpreter that evaluates the AST directly. It is very slow
* Mascal bytecode - the implementation of bytecode compiler before this PR. It is fast, but the compiler needs to calculate and "fixup" addresses.
* Mascal bytecode strflow - the bytecode implementation that uses structural flow. However, it is not optimal because it calculates the jump address every time by scanning the instructions.
* Mascal bytecode strflow-cached - the implementation with cached addresses to jump in the interpreter. It calculates the jump address only once on loading the bytecode.

It is very small difference to measure accurately, so I increased the number of iterations from 256 to 1024 so that the task takes longer time, and extracted only relevant measurements to Mascal.

![mandel-time](https://github.com/user-attachments/assets/fbfb9ac7-4458-4912-a3b3-ac44ac009004)

It is still marginal difference, but it seems consistent that the speed is `Mascal strflow < Mascal strflow-cached < Mascal bytecode`. It makes sense because the timing of calculating jump addresses are like below:

* Mascal bytecode
  * Compile 
    * Calculate jump address (fixup)
  * Load
  * Execute
* Mascal strflow-cached
  * Compile
  * Load
    * Calculate jump address (fixup)
  * Execute
* Mascal strflow
  * Compile
  * Load
  * Execute
    * Calculate jump address (fixup)

As you go down, it comes closer to the runtime, so it will put more workload on the execution.

Also note that I added `Mascal varlen`, which is an implementation of variable length instructions in bytecode in [varlen branch](https://github.com/msakuta/mascal/tree/varlen). It is the most compact representation, but not necessarily the fastest.

# Conclusion

The performance is marginally better if we calculate the jump address at compile times (as real CPU instructions do), but the overhead can be minimized by caching the jump addresses at loading time.

Do we still want to apply this change? We want to have variable length instructions to minimize cache memory requirement for the instructions, which would require structural control flow. However, experiments show that variable length encoding adds significant runtime overhead, which cancels the benefit of memory locality.