### PR TITLE
Text based UI for interactive debugger

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -3,12 +3,18 @@
 version = 3
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.18",
  "libc",
  "winapi",
 ]
@@ -26,10 +32,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bitflags"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
 name = "bytecount"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
+
+[[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
@@ -38,7 +71,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
 dependencies = [
  "atty",
- "bitflags",
+ "bitflags 1.2.1",
  "clap_derive",
  "clap_lex",
  "indexmap",
@@ -54,11 +87,11 @@ version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
- "heck",
+ "heck 0.4.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -82,16 +115,100 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6050c3a16ddab2e412160b31f2c871015704239bca62f72f6e5f0be631d3f644"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.6.0",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "either"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "errno"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "hashbrown"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -103,14 +220,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
 name = "indexmap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
+
+[[package]]
+name = "instability"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b23a0c8dfe501baac4adf6ebbfa6eddf8f0c07f56b058cc1288017e32397846c"
+dependencies = [
+ "quote",
+ "syn 2.0.79",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "lazy_static"
@@ -120,9 +268,40 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.93"
+version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.0",
+]
 
 [[package]]
 name = "mascal"
@@ -139,6 +318,7 @@ dependencies = [
  "clap",
  "colored",
  "mascal",
+ "ratatui",
 ]
 
 [[package]]
@@ -152,6 +332,19 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "mio"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+dependencies = [
+ "hermit-abi 0.3.9",
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys",
+]
 
 [[package]]
 name = "nom"
@@ -187,6 +380,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,7 +417,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.99",
  "version_check",
 ]
 
@@ -212,21 +434,124 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "ratatui"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdef7f9be5c0122f890d58bdf4d964349ba6a6161f705907526d891efabba57d"
+dependencies = [
+ "bitflags 2.6.0",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum",
+ "strum_macros",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+dependencies = [
+ "bitflags 2.6.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+dependencies = [
+ "bitflags 2.6.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+
+[[package]]
+name = "ryu"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -235,10 +560,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.79",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -267,10 +625,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
 name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi"
@@ -302,3 +689,76 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -10,5 +10,6 @@ edition = "2018"
 mascal = { path = "../parser" }
 clap = { version = "3.2.22", features = ["derive"] }
 colored = "2.0.0"
+ratatui = "0.28.1"
 
 

--- a/cli/src/debugger.rs
+++ b/cli/src/debugger.rs
@@ -1,0 +1,56 @@
+//! Implementation of the interactive debugger.
+
+use ratatui::{
+    crossterm::event::{self, KeyCode, KeyEventKind},
+    style::Stylize,
+    widgets::Paragraph,
+    DefaultTerminal,
+};
+
+use ::mascal::Bytecode;
+
+pub(crate) fn run_debugger(bytecode: &Bytecode) -> Result<(), Box<dyn std::error::Error>> {
+    let mut terminal = ratatui::init();
+    terminal.clear()?;
+    let app_result = main_loop(terminal, &bytecode);
+    ratatui::restore();
+    // Error out after restore
+    app_result
+}
+
+fn main_loop(
+    mut terminal: DefaultTerminal,
+    bytecode: &Bytecode,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let message = "\
+    d: disassemble current code
+    r: run current code
+    q: quit";
+    let mut buffer: Option<String> = None;
+    loop {
+        terminal.draw(|frame| {
+            let greeting = Paragraph::new(buffer.as_ref().map_or(message, |b| b.as_str()))
+                .white()
+                .on_blue();
+            frame.render_widget(greeting, frame.area());
+        })?;
+
+        if let event::Event::Key(key) = event::read()? {
+            if key.kind == KeyEventKind::Press && key.code == KeyCode::Char('d') {
+                let mut temp = vec![];
+                bytecode.disasm(&mut temp)?;
+                buffer = Some(format!(
+                    "Showing disassembly (q to quit):\n{}",
+                    String::from_utf8(temp)?
+                ));
+            }
+            if key.kind == KeyEventKind::Press && matches!(key.code, KeyCode::Char('q' | 'Q')) {
+                if buffer.is_some() {
+                    buffer = None;
+                } else {
+                    return Ok(());
+                }
+            }
+        }
+    }
+}

--- a/cli/src/debugger.rs
+++ b/cli/src/debugger.rs
@@ -1,10 +1,17 @@
 //! Implementation of the interactive debugger.
 
 use ratatui::{
+    buffer::Buffer,
     crossterm::event::{self, KeyCode, KeyEventKind},
+    layout::{Alignment, Rect},
     style::Stylize,
-    widgets::Paragraph,
-    DefaultTerminal,
+    symbols::border,
+    text::{Line, Text},
+    widgets::{
+        block::{Position, Title},
+        Block, Paragraph, Widget,
+    },
+    DefaultTerminal, Frame,
 };
 
 use ::mascal::Bytecode;
@@ -12,45 +19,120 @@ use ::mascal::Bytecode;
 pub(crate) fn run_debugger(bytecode: &Bytecode) -> Result<(), Box<dyn std::error::Error>> {
     let mut terminal = ratatui::init();
     terminal.clear()?;
-    let app_result = main_loop(terminal, &bytecode);
+    let app_result = App::new(bytecode).run(terminal);
     ratatui::restore();
     // Error out after restore
     app_result
 }
 
-fn main_loop(
-    mut terminal: DefaultTerminal,
-    bytecode: &Bytecode,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let message = "\
-    d: disassemble current code
-    r: run current code
-    q: quit";
-    let mut buffer: Option<String> = None;
-    loop {
-        terminal.draw(|frame| {
-            let greeting = Paragraph::new(buffer.as_ref().map_or(message, |b| b.as_str()))
-                .white()
-                .on_blue();
-            frame.render_widget(greeting, frame.area());
-        })?;
+struct App<'a> {
+    bytecode: &'a Bytecode,
+    mode: AppMode,
+    exit: bool,
+}
 
+impl<'a> App<'a> {
+    fn new(bytecode: &'a Bytecode) -> Self {
+        Self {
+            bytecode,
+            mode: Default::default(),
+            exit: false,
+        }
+    }
+
+    fn run(&mut self, mut terminal: DefaultTerminal) -> Result<(), Box<dyn std::error::Error>> {
+        while !self.exit {
+            terminal.draw(|frame| self.draw(frame))?;
+            self.handle_events()?;
+        }
+        Ok(())
+    }
+
+    fn draw(&self, frame: &mut Frame) {
+        frame.render_widget(self, frame.area());
+    }
+
+    fn handle_events(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         if let event::Event::Key(key) = event::read()? {
             if key.kind == KeyEventKind::Press && key.code == KeyCode::Char('d') {
                 let mut temp = vec![];
-                bytecode.disasm(&mut temp)?;
-                buffer = Some(format!(
-                    "Showing disassembly (q to quit):\n{}",
-                    String::from_utf8(temp)?
-                ));
+                self.bytecode.disasm(&mut temp)?;
+                self.mode = AppMode::Disasm {
+                    text: String::from_utf8(temp)?,
+                    scroll: 0,
+                };
             }
             if key.kind == KeyEventKind::Press && matches!(key.code, KeyCode::Char('q' | 'Q')) {
-                if buffer.is_some() {
-                    buffer = None;
+                if !matches!(self.mode, AppMode::None) {
+                    self.mode = AppMode::None;
                 } else {
-                    return Ok(());
+                    self.exit = true;
+                }
+            }
+            if key.kind == KeyEventKind::Press {
+                match key.code {
+                    KeyCode::Up => {
+                        if let AppMode::Disasm { ref mut scroll, .. } = self.mode {
+                            *scroll = scroll.saturating_sub(1)
+                        }
+                    }
+                    KeyCode::Down => {
+                        if let AppMode::Disasm { ref mut scroll, .. } = self.mode {
+                            *scroll += 1
+                        }
+                    }
+                    _ => {}
                 }
             }
         }
+        Ok(())
     }
+}
+
+impl<'a> Widget for &App<'a> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let title = Title::from(" Interactive debugger ".bold());
+        let instructions = Title::from(Line::from(vec![
+            " disassemble current code: ".into(),
+            "d".blue().bold(),
+            "  run current code: ".into(),
+            "r".blue().bold(),
+            "  quit: ".into(),
+            "q".blue().bold(),
+        ]));
+        let block = Block::bordered()
+            .title(title.alignment(Alignment::Center))
+            .title(
+                instructions
+                    .alignment(Alignment::Center)
+                    .position(Position::Bottom),
+            )
+            .border_set(border::THICK);
+
+        let disasm_msg = "Showing disassembly (q to quit)";
+
+        let inner_text = match &self.mode {
+            AppMode::None => Text::from(vec![Line::from("Press Q to exit")]),
+            AppMode::Disasm { text, scroll } => {
+                let text_lines: Vec<_> = text.split('\n').collect();
+                let mut lines = vec![format!("{disasm_msg}: {scroll}/{}", text_lines.len()).into()];
+                if *scroll < text_lines.len() {
+                    lines.extend(text_lines[*scroll..].iter().map(|v| Line::from(*v)));
+                }
+                Text::from(lines)
+            }
+        };
+
+        Paragraph::new(inner_text).block(block).render(area, buf);
+    }
+}
+
+#[derive(Default)]
+enum AppMode {
+    #[default]
+    None,
+    Disasm {
+        text: String,
+        scroll: usize,
+    },
 }

--- a/cli/src/debugger.rs
+++ b/cli/src/debugger.rs
@@ -30,7 +30,7 @@ use self::{
 };
 
 pub(crate) fn run_debugger(mut bytecode: Bytecode) -> Result<(), Box<dyn std::error::Error>> {
-    let mut output_buffer = Rc::new(RefCell::new(vec![]));
+    let output_buffer = Rc::new(RefCell::new(vec![]));
     bytecode.add_std_fn(output_buffer.clone());
     let mut terminal = ratatui::init();
     terminal.clear()?;
@@ -118,6 +118,9 @@ impl<'a> App<'a> {
                     } else {
                         self.widgets.stack = StackWidget::new().ok();
                     }
+                }
+                (KeyEventKind::Press, KeyCode::Char('o')) => {
+                    self.widgets.output.toggle_visible();
                 }
                 (KeyEventKind::Press, KeyCode::Char('h')) => {
                     if self.widgets.help.is_some() {

--- a/cli/src/debugger.rs
+++ b/cli/src/debugger.rs
@@ -31,6 +31,7 @@ pub(crate) fn run_debugger(bytecode: &Bytecode) -> Result<(), Box<dyn std::error
 struct App<'a> {
     bytecode: &'a Bytecode,
     mode: AppMode<'a>,
+    disasm: Option<DisasmWidget>,
     exit: bool,
 }
 
@@ -39,6 +40,7 @@ impl<'a> App<'a> {
         Self {
             bytecode,
             mode: Default::default(),
+            disasm: None,
             exit: false,
         }
     }
@@ -59,12 +61,11 @@ impl<'a> App<'a> {
         if let event::Event::Key(key) = event::read()? {
             match (key.kind, key.code) {
                 (KeyEventKind::Press, KeyCode::Char('d')) => {
-                    let mut temp = vec![];
-                    self.bytecode.disasm(&mut temp)?;
-                    self.mode = AppMode::Disasm {
-                        text: String::from_utf8(temp)?,
-                        scroll: 0,
-                    };
+                    if self.disasm.is_some() {
+                        self.disasm = None;
+                    } else {
+                        self.disasm = DisasmWidget::new(self.bytecode).ok();
+                    }
                 }
                 (KeyEventKind::Press, KeyCode::Char('r')) => {
                     interpret(self.bytecode)?;
@@ -94,13 +95,13 @@ impl<'a> App<'a> {
                     }
                 }
                 (KeyEventKind::Press, KeyCode::Up) => {
-                    if let AppMode::Disasm { ref mut scroll, .. } = self.mode {
-                        *scroll = scroll.saturating_sub(1)
+                    if let Some(ref mut da) = self.disasm {
+                        da.scroll = da.scroll.saturating_sub(1)
                     }
                 }
                 (KeyEventKind::Press, KeyCode::Down) => {
-                    if let AppMode::Disasm { ref mut scroll, .. } = self.mode {
-                        *scroll += 1
+                    if let Some(ref mut da) = self.disasm {
+                        da.scroll += 1
                     }
                 }
                 _ => {}
@@ -132,18 +133,8 @@ impl<'a> Widget for &App<'a> {
             )
             .border_set(border::THICK);
 
-        let disasm_msg = "Showing disassembly (q to quit)";
-
         let inner_text = match &self.mode {
             AppMode::None => Text::from(vec![Line::from("Press Q to exit")]),
-            AppMode::Disasm { text, scroll } => {
-                let text_lines: Vec<_> = text.split('\n').collect();
-                let mut lines = vec![format!("{disasm_msg}: {scroll}/{}", text_lines.len()).into()];
-                if *scroll < text_lines.len() {
-                    lines.extend(text_lines[*scroll..].iter().map(|v| Line::from(*v)));
-                }
-                Text::from(lines)
-            }
             AppMode::StepRun { vm, error } => {
                 if let Some(call_info) = vm.top_call_info() {
                     let mut lines =
@@ -176,6 +167,12 @@ impl<'a> Widget for &App<'a> {
         };
 
         Paragraph::new(inner_text).block(block).render(area, buf);
+
+        let mut disasm_area = area;
+        disasm_area.y = disasm_area.height / 2;
+        disasm_area.height /= 2;
+
+        self.disasm.as_ref().map(|d| d.render(disasm_area, buf));
     }
 }
 
@@ -183,12 +180,46 @@ impl<'a> Widget for &App<'a> {
 enum AppMode<'a> {
     #[default]
     None,
-    Disasm {
-        text: String,
-        scroll: usize,
-    },
     StepRun {
         vm: Vm<'a>,
         error: RefCell<Option<String>>,
     },
+}
+
+struct DisasmWidget {
+    text: String,
+    scroll: usize,
+}
+
+impl DisasmWidget {
+    fn new(bytecode: &Bytecode) -> Result<Self, Box<dyn std::error::Error>> {
+        let mut temp = vec![];
+        bytecode.disasm(&mut temp)?;
+        Ok(Self {
+            text: String::from_utf8(temp)?,
+            scroll: 0,
+        })
+    }
+}
+
+impl Widget for &DisasmWidget {
+    fn render(self, area: Rect, buf: &mut Buffer)
+    where
+        Self: Sized,
+    {
+        let title = Title::from(" Disassembly ".bold());
+        let block = Block::bordered()
+            .title(title.alignment(Alignment::Center))
+            .border_set(border::THICK);
+
+        let text_lines: Vec<_> = self.text.split('\n').collect();
+        let mut lines = vec![format!("{}/{}", self.scroll, text_lines.len()).into()];
+        if self.scroll < text_lines.len() {
+            lines.extend(text_lines[self.scroll..].iter().map(|v| Line::from(*v)));
+        }
+
+        Paragraph::new(Text::from(lines))
+            .block(block)
+            .render(area, buf);
+    }
 }

--- a/cli/src/debugger.rs
+++ b/cli/src/debugger.rs
@@ -131,7 +131,7 @@ impl<'a> App<'a> {
                         let Some(last_vm) = vm_history.front() else {
                             return Err("Missing Vm".into());
                         };
-                        let mut next_vm = last_vm.clone();
+                        let mut next_vm = last_vm.deepclone();
                         next_vm.next_inst()?;
                         self.widgets.update(&mut next_vm, btrace_level)?;
                         vm_history.push_front(next_vm);

--- a/cli/src/debugger.rs
+++ b/cli/src/debugger.rs
@@ -1,6 +1,7 @@
 //! Implementation of the interactive debugger.
 
 mod disasm;
+mod help;
 mod stack;
 mod stack_trace;
 
@@ -22,7 +23,9 @@ use ratatui::{
 
 use ::mascal::{interpret, Bytecode, Vm};
 
-use self::{disasm::DisasmWidget, stack::StackWidget, stack_trace::StackTraceWidget};
+use self::{
+    disasm::DisasmWidget, help::HelpWidget, stack::StackWidget, stack_trace::StackTraceWidget,
+};
 
 pub(crate) fn run_debugger(bytecode: &Bytecode) -> Result<(), Box<dyn std::error::Error>> {
     let mut terminal = ratatui::init();
@@ -39,6 +42,7 @@ struct App<'a> {
     disasm: Option<DisasmWidget>,
     stack_trace: Option<StackTraceWidget>,
     stack: Option<StackWidget>,
+    help: Option<HelpWidget>,
     exit: bool,
 }
 
@@ -50,6 +54,7 @@ impl<'a> App<'a> {
             disasm: DisasmWidget::new(bytecode).ok(),
             stack_trace: StackTraceWidget::new().ok(),
             stack: StackWidget::new().ok(),
+            help: None,
             exit: false,
         }
     }
@@ -88,6 +93,13 @@ impl<'a> App<'a> {
                         self.stack = None;
                     } else {
                         self.stack = StackWidget::new().ok();
+                    }
+                }
+                (KeyEventKind::Press, KeyCode::Char('h')) => {
+                    if self.help.is_some() {
+                        self.help = None;
+                    } else {
+                        self.help = HelpWidget::new().ok();
                     }
                 }
                 (KeyEventKind::Press, KeyCode::Char('r')) => {
@@ -155,91 +167,98 @@ impl<'a> App<'a> {
 impl<'a> Widget for &App<'a> {
     fn render(self, area: Rect, buf: &mut Buffer) {
         let title = Title::from(" Interactive debugger ".bold());
-        let instructions = Title::from(Line::from(vec![
-            "  disassemby: ".into(),
-            "d".blue().bold(),
-            "  stack trace: ".into(),
-            "t".blue().bold(),
-            "  Show local stack values: ".into(),
-            "l".blue().bold(),
-            "  run current code: ".into(),
-            "r".blue().bold(),
-            "  Step execution mode: ".into(),
-            "s".blue().bold(),
-            "  quit: ".into(),
-            "q ".blue().bold(),
-        ]));
-        let block = Block::bordered()
-            .title(title.alignment(Alignment::Center))
-            .title(
-                instructions
-                    .alignment(Alignment::Center)
-                    .position(Position::Bottom),
-            )
-            .border_set(border::THICK);
+        // Help shows on top of all widgets
+        if let Some(ref help) = self.help {
+            let mut help_area = area;
+            help_area.x += help_area.width / 4;
+            help_area.width /= 2;
+            help_area.y += help_area.height / 4;
+            help_area.height /= 2;
+            help.render(help_area, buf);
+        } else {
+            let instructions = Title::from(Line::from(vec![
+                "  help: ".into(),
+                "h".blue().bold(),
+                "  quit: ".into(),
+                "q ".blue().bold(),
+            ]));
+            let block = Block::bordered()
+                .title(title.alignment(Alignment::Center))
+                .title(
+                    instructions
+                        .alignment(Alignment::Center)
+                        .position(Position::Bottom),
+                )
+                .border_set(border::THICK);
 
-        let inner_text = match &self.mode {
-            AppMode::None => Text::from(vec![Line::from("Press Q to exit")]),
-            AppMode::StepRun { vm, error } => {
-                if let Some(call_info) = vm.top_call_info() {
-                    let mut lines =
-                        vec![format!("Execution state at {}", call_info.instuction_ptr()).into()];
+            let inner_text = match &self.mode {
+                AppMode::None => Text::from(vec![
+                    Line::from("Press Q to exit"),
+                    Line::from("Press H for help"),
+                ]),
+                AppMode::StepRun { vm, error } => {
+                    if let Some(call_info) = vm.top_call_info() {
+                        let mut lines =
+                            vec![
+                                format!("Execution state at {}", call_info.instuction_ptr()).into()
+                            ];
 
-                    let mut buf = vec![];
-                    if let Err(e) = vm.dump_stack(&mut buf) {
-                        *error.borrow_mut() = Some(e.to_string());
-                    }
-                    if let Ok(s) = String::from_utf8(buf) {
-                        lines.push(s.into());
-                    }
+                        let mut buf = vec![];
+                        if let Err(e) = vm.dump_stack(&mut buf) {
+                            *error.borrow_mut() = Some(e.to_string());
+                        }
+                        if let Ok(s) = String::from_utf8(buf) {
+                            lines.push(s.into());
+                        }
 
-                    let mut buf = vec![];
-                    if let Err(e) = vm.format_current_inst(&mut buf) {
-                        *error.borrow_mut() = Some(e.to_string());
-                    }
-                    if let Ok(s) = String::from_utf8(buf) {
-                        lines.push(s.into());
-                    }
+                        let mut buf = vec![];
+                        if let Err(e) = vm.format_current_inst(&mut buf) {
+                            *error.borrow_mut() = Some(e.to_string());
+                        }
+                        if let Ok(s) = String::from_utf8(buf) {
+                            lines.push(s.into());
+                        }
 
-                    if let Some(error) = error.borrow().as_ref() {
-                        lines.push(format!("Error: {error}").into());
+                        if let Some(error) = error.borrow().as_ref() {
+                            lines.push(format!("Error: {error}").into());
+                        }
+                        Text::from(lines)
+                    } else {
+                        Text::from("Step exection has not started yet.")
                     }
-                    Text::from(lines)
-                } else {
-                    Text::from("Step exection has not started yet.")
                 }
-            }
-        };
+            };
 
-        Paragraph::new(inner_text).block(block).render(area, buf);
+            Paragraph::new(inner_text).block(block).render(area, buf);
 
-        let mut tr_area = area;
-        if 0 < tr_area.height {
-            tr_area.x = area.width / 2;
-            tr_area.width /= 2;
-            tr_area.y += 1;
-            tr_area.height = (tr_area.height - 1) / 2;
-            self.stack.as_ref().map(|d| d.render(tr_area, buf));
-        }
-
-        let mut widget_area = area;
-        if 0 < widget_area.height {
-            widget_area.y = widget_area.height / 2;
-            widget_area.height = (widget_area.height - 1) / 2;
-
-            let widget_count = self.disasm.is_some() as u16 + self.stack_trace.is_some() as u16;
-
-            if widget_count != 0 {
-                widget_area.width /= widget_count;
+            let mut tr_area = area;
+            if 0 < tr_area.height {
+                tr_area.x = area.width / 2;
+                tr_area.width /= 2;
+                tr_area.y += 1;
+                tr_area.height = (tr_area.height - 1) / 2;
+                self.stack.as_ref().map(|d| d.render(tr_area, buf));
             }
 
-            if let Some(d) = self.disasm.as_ref() {
-                d.render(widget_area, buf);
-                widget_area.x += widget_area.width;
+            let mut widget_area = area;
+            if 0 < widget_area.height {
+                widget_area.y = widget_area.height / 2;
+                widget_area.height = (widget_area.height - 1) / 2;
+
+                let widget_count = self.disasm.is_some() as u16 + self.stack_trace.is_some() as u16;
+
+                if widget_count != 0 {
+                    widget_area.width /= widget_count;
+                }
+
+                if let Some(d) = self.disasm.as_ref() {
+                    d.render(widget_area, buf);
+                    widget_area.x += widget_area.width;
+                }
+                self.stack_trace
+                    .as_ref()
+                    .map(|d| d.render(widget_area, buf));
             }
-            self.stack_trace
-                .as_ref()
-                .map(|d| d.render(widget_area, buf));
         }
     }
 }

--- a/cli/src/debugger/disasm.rs
+++ b/cli/src/debugger/disasm.rs
@@ -1,0 +1,64 @@
+use mascal::{Bytecode, FnBytecode};
+use ratatui::{
+    buffer::Buffer,
+    layout::{Alignment, Rect},
+    style::{Style, Stylize},
+    symbols::border,
+    text::{Line, Text},
+    widgets::{block::Title, Block, Paragraph, Widget},
+};
+
+pub(super) struct DisasmWidget {
+    pub(super) text: String,
+    pub(super) scroll: usize,
+}
+
+impl DisasmWidget {
+    pub(super) fn new(bytecode: &Bytecode) -> Result<Self, Box<dyn std::error::Error>> {
+        let mut temp = vec![];
+        bytecode.disasm(&mut temp)?;
+        Ok(Self {
+            text: String::from_utf8(temp)?,
+            scroll: 0,
+        })
+    }
+
+    pub(super) fn update(
+        &mut self,
+        bytecode: &FnBytecode,
+        ip: usize,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut temp = String::new();
+        for (i, inst) in bytecode.iter_instructions().enumerate() {
+            let current = if i == ip { "*" } else { " " };
+            temp += &format!("{current}  [{}] {}\n", i, inst);
+        }
+        self.text = temp;
+        self.scroll = ip.saturating_sub(3); // Leave 3 lines before
+        Ok(())
+    }
+}
+
+impl Widget for &DisasmWidget {
+    fn render(self, area: Rect, buf: &mut Buffer)
+    where
+        Self: Sized,
+    {
+        let text_lines: Vec<_> = self.text.split('\n').collect();
+        let title =
+            Title::from(format!(" Disassembly {}/{} ", self.scroll, text_lines.len()).bold());
+        let block = Block::bordered()
+            .title(title.alignment(Alignment::Center))
+            .border_style(Style::new().yellow())
+            .border_set(border::THICK);
+
+        let mut lines = vec![];
+        if self.scroll < text_lines.len() {
+            lines.extend(text_lines[self.scroll..].iter().map(|v| Line::from(*v)));
+        }
+
+        Paragraph::new(Text::from(lines))
+            .block(block)
+            .render(area, buf);
+    }
+}

--- a/cli/src/debugger/help.rs
+++ b/cli/src/debugger/help.rs
@@ -25,7 +25,7 @@ impl Widget for &HelpWidget {
                 "  Toggle help (this window): ".into(),
                 "h".blue().bold(),
             ]),
-            Line::from(vec!["  Toggle disassembly: ".into(), "d".blue().bold()]),
+            Line::from(vec!["  Toggle disassembly: ".into(), "D".blue().bold()]),
             Line::from(vec!["  Toggle stack trace: ".into(), "t".blue().bold()]),
             Line::from(vec![
                 "  Toggle local stack values: ".into(),
@@ -33,6 +33,8 @@ impl Widget for &HelpWidget {
             ]),
             Line::from(vec!["  run current code: ".into(), "r".blue().bold()]),
             Line::from(vec!["  Step execution mode: ".into(), "s".blue().bold()]),
+            Line::from(vec!["  Move up stack frame: ".into(), "u".blue().bold()]),
+            Line::from(vec!["  Move down stack frame: ".into(), "d".blue().bold()]),
             Line::from(vec!["  quit: ".into(), "q ".blue().bold()]),
         ]);
         let title = Title::from(" Help ".bold());

--- a/cli/src/debugger/help.rs
+++ b/cli/src/debugger/help.rs
@@ -1,0 +1,48 @@
+use ratatui::{
+    buffer::Buffer,
+    layout::{Alignment, Rect},
+    style::{Color, Style, Stylize},
+    symbols::border,
+    text::{Line, Text},
+    widgets::{block::Title, Block, Paragraph, Widget},
+};
+
+pub(super) struct HelpWidget {}
+
+impl HelpWidget {
+    pub(super) fn new() -> Result<Self, Box<dyn std::error::Error>> {
+        Ok(Self {})
+    }
+}
+
+impl Widget for &HelpWidget {
+    fn render(self, area: Rect, buf: &mut Buffer)
+    where
+        Self: Sized,
+    {
+        let text_lines = Text::from(vec![
+            Line::from(vec![
+                "  Toggle help (this window): ".into(),
+                "h".blue().bold(),
+            ]),
+            Line::from(vec!["  Toggle disassembly: ".into(), "d".blue().bold()]),
+            Line::from(vec!["  Toggle stack trace: ".into(), "t".blue().bold()]),
+            Line::from(vec![
+                "  Toggle local stack values: ".into(),
+                "l".blue().bold(),
+            ]),
+            Line::from(vec!["  run current code: ".into(), "r".blue().bold()]),
+            Line::from(vec!["  Step execution mode: ".into(), "s".blue().bold()]),
+            Line::from(vec!["  quit: ".into(), "q ".blue().bold()]),
+        ]);
+        let title = Title::from(" Help ".bold());
+        let block = Block::bordered()
+            .title(title.alignment(Alignment::Center))
+            // .bg(Color::Blue)
+            .style(Style::default().bg(Color::DarkGray))
+            .border_style(Style::new().white())
+            .border_set(border::THICK);
+
+        Paragraph::new(text_lines).block(block).render(area, buf);
+    }
+}

--- a/cli/src/debugger/help.rs
+++ b/cli/src/debugger/help.rs
@@ -31,6 +31,7 @@ impl Widget for &HelpWidget {
                 "  Toggle local stack values: ".into(),
                 "l".blue().bold(),
             ]),
+            Line::from(vec!["  Toggle output widget: ".into(), "o".blue().bold()]),
             Line::from(vec!["  run current code: ".into(), "r".blue().bold()]),
             Line::from(vec!["  Step execution mode: ".into(), "s".blue().bold()]),
             Line::from(vec!["  Move up stack frame: ".into(), "u".blue().bold()]),

--- a/cli/src/debugger/help.rs
+++ b/cli/src/debugger/help.rs
@@ -35,6 +35,14 @@ impl Widget for &HelpWidget {
             Line::from(vec!["  Step execution mode: ".into(), "s".blue().bold()]),
             Line::from(vec!["  Move up stack frame: ".into(), "u".blue().bold()]),
             Line::from(vec!["  Move down stack frame: ".into(), "d".blue().bold()]),
+            Line::from(vec![
+                "  Previous state in time travel debugger: ".into(),
+                "p".blue().bold(),
+            ]),
+            Line::from(vec![
+                "  Next state in time travel debugger: ".into(),
+                "n".blue().bold(),
+            ]),
             Line::from(vec!["  quit: ".into(), "q ".blue().bold()]),
         ]);
         let title = Title::from(" Help ".bold());

--- a/cli/src/debugger/stack.rs
+++ b/cli/src/debugger/stack.rs
@@ -1,0 +1,54 @@
+use mascal::Vm;
+use ratatui::{
+    buffer::Buffer,
+    layout::{Alignment, Rect},
+    style::{Style, Stylize},
+    symbols::border,
+    text::{Line, Text},
+    widgets::{block::Title, Block, Paragraph, Widget},
+};
+
+pub(super) struct StackWidget {
+    text: String,
+    scroll: usize,
+}
+
+impl StackWidget {
+    pub(super) fn new() -> Result<Self, Box<dyn std::error::Error>> {
+        Ok(Self {
+            text: String::new(),
+            scroll: 0,
+        })
+    }
+
+    pub(super) fn update(&mut self, vm: &Vm) -> Result<(), Box<dyn std::error::Error>> {
+        let mut buf = vec![];
+        vm.print_stack(&mut buf)?;
+        self.text = String::from_utf8(buf)?;
+        Ok(())
+    }
+}
+
+impl Widget for &StackWidget {
+    fn render(self, area: Rect, buf: &mut Buffer)
+    where
+        Self: Sized,
+    {
+        let text_lines: Vec<_> = self.text.split('\n').collect();
+        let title =
+            Title::from(format!(" Stack values {}/{} ", self.scroll, text_lines.len()).bold());
+        let block = Block::bordered()
+            .title(title.alignment(Alignment::Center))
+            .border_style(Style::new().cyan())
+            .border_set(border::THICK);
+
+        let mut lines = vec![];
+        if self.scroll < text_lines.len() {
+            lines.extend(text_lines[self.scroll..].iter().map(|v| Line::from(*v)));
+        }
+
+        Paragraph::new(Text::from(lines))
+            .block(block)
+            .render(area, buf);
+    }
+}

--- a/cli/src/debugger/stack.rs
+++ b/cli/src/debugger/stack.rs
@@ -21,9 +21,13 @@ impl StackWidget {
         })
     }
 
-    pub(super) fn update(&mut self, vm: &Vm) -> Result<(), Box<dyn std::error::Error>> {
+    pub(super) fn update(
+        &mut self,
+        vm: &Vm,
+        level: usize,
+    ) -> Result<(), Box<dyn std::error::Error>> {
         let mut buf = vec![];
-        vm.print_stack(&mut buf)?;
+        vm.print_stack(&mut buf, level)?;
         self.text = String::from_utf8(buf)?;
         Ok(())
     }

--- a/cli/src/debugger/stack_trace.rs
+++ b/cli/src/debugger/stack_trace.rs
@@ -21,9 +21,13 @@ impl StackTraceWidget {
         })
     }
 
-    pub(super) fn update(&mut self, vm: &Vm) -> Result<(), Box<dyn std::error::Error>> {
+    pub(super) fn update(
+        &mut self,
+        vm: &Vm,
+        level: usize,
+    ) -> Result<(), Box<dyn std::error::Error>> {
         let mut buf = vec![];
-        vm.stack_trace(&mut buf)?;
+        vm.stack_trace(level, &mut buf)?;
         self.text = String::from_utf8(buf)?;
         Ok(())
     }
@@ -35,8 +39,14 @@ impl Widget for &StackTraceWidget {
         Self: Sized,
     {
         let text_lines: Vec<_> = self.text.split('\n').collect();
-        let title =
-            Title::from(format!(" Stack trace {}/{} ", self.scroll, text_lines.len()).bold());
+        let title = Title::from(
+            format!(
+                " Stack trace (most recent last) {}/{} ",
+                self.scroll,
+                text_lines.len()
+            )
+            .bold(),
+        );
         let block = Block::bordered()
             .title(title.alignment(Alignment::Center))
             .border_style(Style::new().blue())

--- a/cli/src/debugger/stack_trace.rs
+++ b/cli/src/debugger/stack_trace.rs
@@ -1,0 +1,54 @@
+use mascal::Vm;
+use ratatui::{
+    buffer::Buffer,
+    layout::{Alignment, Rect},
+    style::{Style, Stylize},
+    symbols::border,
+    text::{Line, Text},
+    widgets::{block::Title, Block, Paragraph, Widget},
+};
+
+pub(super) struct StackTraceWidget {
+    text: String,
+    scroll: usize,
+}
+
+impl StackTraceWidget {
+    pub(super) fn new() -> Result<Self, Box<dyn std::error::Error>> {
+        Ok(Self {
+            text: String::new(),
+            scroll: 0,
+        })
+    }
+
+    pub(super) fn update(&mut self, vm: &Vm) -> Result<(), Box<dyn std::error::Error>> {
+        let mut buf = vec![];
+        vm.stack_trace(&mut buf)?;
+        self.text = String::from_utf8(buf)?;
+        Ok(())
+    }
+}
+
+impl Widget for &StackTraceWidget {
+    fn render(self, area: Rect, buf: &mut Buffer)
+    where
+        Self: Sized,
+    {
+        let text_lines: Vec<_> = self.text.split('\n').collect();
+        let title =
+            Title::from(format!(" Stack trace {}/{} ", self.scroll, text_lines.len()).bold());
+        let block = Block::bordered()
+            .title(title.alignment(Alignment::Center))
+            .border_style(Style::new().blue())
+            .border_set(border::THICK);
+
+        let mut lines = vec![];
+        if self.scroll < text_lines.len() {
+            lines.extend(text_lines[self.scroll..].iter().map(|v| Line::from(*v)));
+        }
+
+        Paragraph::new(Text::from(lines))
+            .block(block)
+            .render(area, buf);
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -6,9 +6,11 @@ use mascal::*;
 
 use ::colored::Colorize;
 use std::{
+    cell::RefCell,
     collections::HashMap,
     fs::File,
     io::{prelude::*, BufReader, BufWriter},
+    rc::Rc,
 };
 
 #[derive(Parser, Debug)]
@@ -81,10 +83,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     .map_err(|s| s.to_string())?;
             }
             if args.compile_and_run {
-                bytecode.add_std_fn();
                 if args.debugger {
-                    run_debugger(&bytecode)?;
+                    run_debugger(bytecode)?;
                 } else {
+                    let out = Rc::new(RefCell::new(std::io::stdout()));
+                    bytecode.add_std_fn(out);
                     interpret(&bytecode)?;
                 }
             }
@@ -112,7 +115,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     .disasm(&mut std::io::stdout())
                     .map_err(|e| e.to_string())?;
             }
-            bytecode.add_std_fn();
+            let out = Rc::new(RefCell::new(std::io::stdout()));
+            bytecode.add_std_fn(out);
             interpret(&bytecode).map_err(|e| e.to_string())?;
         } else {
             let mut contents = String::new();

--- a/parser/src/bytecode.rs
+++ b/parser/src/bytecode.rs
@@ -199,6 +199,9 @@ pub(crate) fn read_opt_value(reader: &mut impl Read) -> Result<Option<Value>, Re
 
 pub type NativeFn = Box<dyn Fn(&[Value]) -> Result<Value, EvalError>>;
 
+/// A mapping from function name to function prototypes, which can be a bytecode or a native extension.
+pub(crate) type FnProtos = HashMap<String, FnProto>;
+
 pub(crate) enum FnProto {
     Code(FnBytecode),
     Native(NativeFn),

--- a/parser/src/bytecode.rs
+++ b/parser/src/bytecode.rs
@@ -290,6 +290,17 @@ impl Bytecode {
         Ok(())
     }
 
+    /// Returns a FnBytecode of a named function if it is included in this bytecode.
+    pub fn fn_bytecode(&self, name: &str) -> Option<&FnBytecode> {
+        self.functions.get(name).and_then(|f| {
+            if let FnProto::Code(code) = f {
+                Some(code)
+            } else {
+                None
+            }
+        })
+    }
+
     pub fn signatures(&self, out: &mut impl Write) -> std::io::Result<()> {
         for (fname, fnproto) in &self.functions {
             match fnproto {
@@ -467,5 +478,9 @@ impl FnBytecode {
             }
         }
         Ok(())
+    }
+
+    pub fn iter_instructions(&self) -> impl Iterator<Item = &Instruction> {
+        self.instructions.iter()
     }
 }

--- a/parser/src/bytecode.rs
+++ b/parser/src/bytecode.rs
@@ -5,7 +5,6 @@ use std::{
     collections::HashMap,
     convert::{TryFrom, TryInto},
     io::{Read, Write},
-    ops::DerefMut,
     rc::Rc,
 };
 

--- a/parser/src/compiler.rs
+++ b/parser/src/compiler.rs
@@ -52,7 +52,8 @@ struct CompilerEnv {
 
 impl CompilerEnv {
     fn new(mut functions: HashMap<String, FnProto>) -> Self {
-        std_functions(&mut |name, f| {
+        let out = Rc::new(RefCell::new(std::io::stdout()));
+        std_functions(out, &mut |name, f| {
             functions.insert(name, FnProto::Native(f));
         });
         Self { functions }

--- a/parser/src/interpreter.rs
+++ b/parser/src/interpreter.rs
@@ -8,7 +8,7 @@ use crate::{
     value::{ArrayInt, TupleEntry},
     TypeDecl, Value,
 };
-use std::{cell::RefCell, collections::HashMap, rc::Rc};
+use std::{cell::RefCell, collections::HashMap, io::Write, rc::Rc};
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum RunResult {
@@ -26,7 +26,7 @@ pub type EvalResult<T> = Result<T, EvalError>;
 /// The information about the error shold be converted to a string (by `format!("{:?}")`) before wrapping it
 /// into `EvalError`.
 #[non_exhaustive]
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub enum EvalError {
     Other(String),
     CoerceError(String, String),
@@ -55,6 +55,7 @@ pub enum EvalError {
     IndexNonNum,
     NonLValue(String),
     PrematureEnd,
+    IOError(std::io::Error),
 }
 
 impl std::error::Error for EvalError {}
@@ -122,6 +123,7 @@ impl std::fmt::Display for EvalError {
             Self::PrematureEnd => {
                 write!(f, "End of input bytecode encountered before seeing a Ret")
             }
+            Self::IOError(e) => e.fmt(f),
         }
     }
 }
@@ -129,6 +131,12 @@ impl std::fmt::Display for EvalError {
 impl From<String> for EvalError {
     fn from(value: String) -> Self {
         Self::Other(value)
+    }
+}
+
+impl From<std::io::Error> for EvalError {
+    fn from(value: std::io::Error) -> Self {
+        Self::IOError(value)
     }
 }
 
@@ -649,61 +657,65 @@ where
     })
 }
 
-pub(crate) fn s_print(vals: &[Value]) -> EvalResult<Value> {
-    fn print_inner(val: &Value) -> EvalResult<()> {
+pub(crate) fn s_print(out: &mut dyn Write, vals: &[Value]) -> EvalResult<Value> {
+    fn print_inner(out: &mut dyn Write, val: &Value) -> EvalResult<()> {
         match val {
-            Value::F64(val) => print!("{}", val),
-            Value::F32(val) => print!("{}", val),
-            Value::I64(val) => print!("{}", val),
-            Value::I32(val) => print!("{}", val),
-            Value::Str(val) => print!("{}", val),
+            Value::F64(val) => write!(out, "{}", val)?,
+            Value::F32(val) => write!(out, "{}", val)?,
+            Value::I64(val) => write!(out, "{}", val)?,
+            Value::I32(val) => write!(out, "{}", val)?,
+            Value::Str(val) => write!(out, "{}", val)?,
             Value::Array(val) => {
-                print!("[");
+                write!(out, "[")?;
                 for (i, val) in val.borrow().values.iter().enumerate() {
                     if i != 0 {
-                        print!(", ");
+                        write!(out, ", ")?;
                     }
-                    print_inner(val)?;
+                    print_inner(out, val)?;
                 }
-                print!("]");
+                write!(out, "]")?;
             }
             Value::Tuple(val) => {
-                print!("(");
+                write!(out, "(")?;
                 for (i, val) in val.borrow().iter().enumerate() {
                     if i != 0 {
-                        print!(", ");
+                        write!(out, ", ")?;
                     }
-                    print_inner(&val.value)?;
+                    print_inner(out, &val.value)?;
                 }
-                print!(")");
+                write!(out, ")")?;
             }
         }
         Ok(())
     }
     for val in vals {
-        print_inner(val)?;
+        print_inner(out, val)?;
         // Put a space between tokens
-        print!(" ");
+        write!(out, " ")?;
     }
-    print!("\n");
+    write!(out, "\n")?;
     Ok(Value::I32(0))
 }
 
-fn s_puts(vals: &[Value]) -> Result<Value, EvalError> {
-    fn puts_inner<'a>(vals: &mut dyn Iterator<Item = &'a Value>) {
+pub(crate) fn s_puts(out: &mut dyn Write, vals: &[Value]) -> Result<Value, EvalError> {
+    fn puts_inner<'a>(
+        out: &mut dyn Write,
+        vals: &mut dyn Iterator<Item = &'a Value>,
+    ) -> std::io::Result<()> {
         for val in vals {
             match val {
-                Value::F64(val) => print!("{}", val),
-                Value::F32(val) => print!("{}", val),
-                Value::I64(val) => print!("{}", val),
-                Value::I32(val) => print!("{}", val),
-                Value::Str(val) => print!("{}", val),
-                Value::Array(val) => puts_inner(&mut val.borrow().values.iter()),
-                Value::Tuple(val) => puts_inner(&mut val.borrow().iter().map(|v| &v.value)),
+                Value::F64(val) => write!(out, "{}", val)?,
+                Value::F32(val) => write!(out, "{}", val)?,
+                Value::I64(val) => write!(out, "{}", val)?,
+                Value::I32(val) => write!(out, "{}", val)?,
+                Value::Str(val) => write!(out, "{}", val)?,
+                Value::Array(val) => puts_inner(out, &mut val.borrow().values.iter())?,
+                Value::Tuple(val) => puts_inner(out, &mut val.borrow().iter().map(|v| &v.value))?,
             }
         }
+        Ok(())
     }
-    puts_inner(&mut vals.iter());
+    puts_inner(out, &mut vals.iter())?;
     Ok(Value::I32(0))
 }
 
@@ -912,11 +924,15 @@ pub(crate) fn std_functions<'src, 'native>() -> HashMap<String, FuncDef<'src, 'n
     let mut functions = HashMap::new();
     functions.insert(
         "print".to_string(),
-        FuncDef::new_native(&s_print, vec![], None),
+        FuncDef::new_native(&|vals| s_print(&mut std::io::stdout(), vals), vec![], None),
     );
     functions.insert(
         "puts".to_string(),
-        FuncDef::new_native(&s_puts, vec![ArgDecl::new("val", TypeDecl::Any)], None),
+        FuncDef::new_native(
+            &|vals| s_puts(&mut std::io::stdout(), vals),
+            vec![ArgDecl::new("val", TypeDecl::Any)],
+            None,
+        ),
     );
     functions.insert(
         "type".to_string(),

--- a/parser/src/interpreter.rs
+++ b/parser/src/interpreter.rs
@@ -54,6 +54,7 @@ pub enum EvalError {
     AssignToLiteral(String),
     IndexNonNum,
     NonLValue(String),
+    PrematureEnd,
 }
 
 impl std::error::Error for EvalError {}
@@ -118,6 +119,9 @@ impl std::fmt::Display for EvalError {
             Self::AssignToLiteral(name) => write!(f, "Cannot assign to a literal: {}", name),
             Self::IndexNonNum => write!(f, "Indexed an array with a non-number"),
             Self::NonLValue(ex) => write!(f, "Expression {} is not an lvalue.", ex),
+            Self::PrematureEnd => {
+                write!(f, "End of input bytecode encountered before seeing a Ret")
+            }
         }
     }
 }

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -15,7 +15,7 @@ mod type_tags;
 mod value;
 mod vm;
 
-pub use self::bytecode::{Bytecode, Instruction, OpCode};
+pub use self::bytecode::{Bytecode, FnBytecode, Instruction, OpCode};
 pub use self::compiler::*;
 pub use self::interpreter::{coerce_type, run, EvalContext, EvalError, FuncDef};
 pub use self::parser::{span_source as source, ArgDecl, ReadError, Span};

--- a/parser/src/value.rs
+++ b/parser/src/value.rs
@@ -228,6 +228,25 @@ impl Value {
             _ => return Err(EvalError::IndexNonArray),
         })
     }
+
+    pub fn deepclone(&self) -> Self {
+        match self {
+            Self::Array(a) => {
+                let a = a.borrow();
+                let values = a.values.iter().map(|v| v.deepclone()).collect();
+                Self::Array(Rc::new(RefCell::new(ArrayInt{ type_decl: a.type_decl.clone(), values })))
+            }
+            Self::Tuple(a) => {
+                let a = a.borrow();
+                let values = a.iter().map(|v| TupleEntry {
+                    decl: v.decl.clone(),
+                    value: v.value.deepclone(),
+                }).collect();
+                Self::Tuple(Rc::new(RefCell::new( values )))
+            }
+            _ => self.clone(),
+        }
+    }
 }
 
 pub type TupleInt = Vec<TupleEntry>;

--- a/parser/src/value.rs
+++ b/parser/src/value.rs
@@ -234,15 +234,21 @@ impl Value {
             Self::Array(a) => {
                 let a = a.borrow();
                 let values = a.values.iter().map(|v| v.deepclone()).collect();
-                Self::Array(Rc::new(RefCell::new(ArrayInt{ type_decl: a.type_decl.clone(), values })))
+                Self::Array(Rc::new(RefCell::new(ArrayInt {
+                    type_decl: a.type_decl.clone(),
+                    values,
+                })))
             }
             Self::Tuple(a) => {
                 let a = a.borrow();
-                let values = a.iter().map(|v| TupleEntry {
-                    decl: v.decl.clone(),
-                    value: v.value.deepclone(),
-                }).collect();
-                Self::Tuple(Rc::new(RefCell::new( values )))
+                let values = a
+                    .iter()
+                    .map(|v| TupleEntry {
+                        decl: v.decl.clone(),
+                        value: v.value.deepclone(),
+                    })
+                    .collect();
+                Self::Tuple(Rc::new(RefCell::new(values)))
             }
             _ => self.clone(),
         }

--- a/parser/src/vm.rs
+++ b/parser/src/vm.rs
@@ -129,7 +129,8 @@ impl<'a> Vm<'a> {
     }
 
     pub fn call_info(&self, level: usize) -> Option<&CallInfo> {
-        self.call_stack.get(self.call_stack.len().saturating_sub(level + 1))
+        self.call_stack
+            .get(self.call_stack.len().saturating_sub(level + 1))
     }
 
     pub fn format_current_inst(

--- a/parser/src/vm.rs
+++ b/parser/src/vm.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 use crate::{
-    bytecode::{Bytecode, FnBytecode, FnProto, OpCode},
+    bytecode::{Bytecode, FnBytecode, FnProto, FnProtos, OpCode},
     interpreter::{
         binary_op, binary_op_int, binary_op_str, coerce_f64, coerce_i64, coerce_type, truthy,
         EvalError, EvalResult,
@@ -27,7 +27,7 @@ pub fn interpret(bytecode: &Bytecode) -> Result<Value, EvalError> {
     }
 }
 
-struct CallInfo<'a> {
+pub struct CallInfo<'a> {
     fun: &'a FnBytecode,
     ip: usize,
     stack_size: usize,
@@ -35,29 +35,53 @@ struct CallInfo<'a> {
 }
 
 impl<'a> CallInfo<'a> {
-    fn has_next_inst(&self) -> bool {
+    pub fn instuction_ptr(&self) -> usize {
+        self.ip
+    }
+
+    pub fn has_next_inst(&self) -> bool {
         self.ip < self.fun.instructions.len()
     }
 }
 
 /// The virtual machine state run by the bytecode.
-struct Vm {
+/// Now it is a full state machine that has complete information to suspend and resume at any time,
+/// given that the lifetime of the functions are valid.
+pub struct Vm<'a> {
     /// A stack for function call stack frames.
     stack: Vec<Value>,
     /// The stack base address of the currently running function.
     stack_base: usize,
+    call_stack: Vec<CallInfo<'a>>,
     /// A special register to remember the target index in Set instruction, updated by SetReg instruction.
     /// Similar to x64's RSI or RDI, it indicates the index of the array to set, because we need more arguments than
     /// a fixed length arguments in an instruction for Set operation.
     set_register: usize,
+    functions: &'a FnProtos,
 }
 
-impl Vm {
-    fn new(stack_size: usize) -> Self {
+impl<'a> Vm<'a> {
+    fn new(bytecode: &'a FnBytecode, functions: &'a FnProtos) -> Self {
+        let stack_size = bytecode.stack_size;
         Self {
             stack: vec![Value::I64(0); stack_size],
+            call_stack: vec![CallInfo {
+                fun: bytecode,
+                ip: 0,
+                stack_size: stack_size,
+                stack_base: 0,
+            }],
             stack_base: 0,
             set_register: 0,
+            functions,
+        }
+    }
+
+    pub fn start_main(bytecode: &'a Bytecode) -> EvalResult<Self> {
+        if let Some(FnProto::Code(main)) = bytecode.functions.get("") {
+            Ok(Self::new(main, &bytecode.functions))
+        } else {
+            Err(EvalError::NoMainFound)
         }
     }
 
@@ -93,6 +117,10 @@ impl Vm {
                 })
         );
     }
+
+    pub fn top_call_info(&self) -> Option<&CallInfo> {
+        self.call_stack.last()
+    }
 }
 
 /// An extension trait for `Vec` to write a shorthand for
@@ -125,16 +153,21 @@ fn interpret_fn(
     );
     dbg_println!("size callInfo: {}", std::mem::size_of::<CallInfo>());
     dbg_println!("literals: {:?}", bytecode.literals);
-    let mut vm = Vm::new(bytecode.stack_size);
-    let mut call_stack = vec![CallInfo {
-        fun: &bytecode,
-        ip: 0,
-        stack_size: vm.stack.len(),
-        stack_base: vm.stack_base,
-    }];
+    let mut vm = Vm::new(bytecode, functions);
+    let value = loop {
+        if let Some(res) = vm.next_inst()? {
+            break res;
+        }
+    };
+    Ok(value)
+}
 
-    while call_stack.clast()?.has_next_inst() {
-        let ci = call_stack.clast()?;
+impl<'a> Vm<'a> {
+    pub fn next_inst(&mut self) -> Result<Option<Value>, EvalError> {
+        if !self.call_stack.clast()?.has_next_inst() {
+            return Err(EvalError::PrematureEnd);
+        }
+        let ci = self.call_stack.clast()?;
         let ip = ci.ip;
         let inst = ci.fun.instructions[ip];
 
@@ -142,23 +175,23 @@ fn interpret_fn(
 
         match inst.op {
             OpCode::LoadLiteral => {
-                vm.set(inst.arg1, ci.fun.literals[inst.arg0 as usize].clone());
+                self.set(inst.arg1, ci.fun.literals[inst.arg0 as usize].clone());
             }
             OpCode::Move => {
                 if let (Value::Array(lhs), Value::Array(rhs)) =
-                    (vm.get(inst.arg0), vm.get(inst.arg1))
+                    (self.get(inst.arg0), self.get(inst.arg1))
                 {
                     if lhs as *const _ == rhs as *const _ {
                         println!("Self-assignment!");
-                        call_stack.clast_mut()?.ip += 1;
-                        continue;
+                        self.call_stack.clast_mut()?.ip += 1;
+                        return Ok(None);
                     }
                 }
-                let val = vm.get(inst.arg0).clone();
-                vm.set(inst.arg1, val);
+                let val = self.get(inst.arg0).clone();
+                self.set(inst.arg1, val);
             }
             OpCode::Incr => {
-                let val = vm.get_mut(inst.arg0);
+                let val = self.get_mut(inst.arg0);
                 fn incr(val: &mut Value) -> Result<(), String> {
                     match val {
                         Value::I64(i) => *i += 1,
@@ -178,166 +211,172 @@ fn interpret_fn(
             }
             OpCode::Add => {
                 let result = binary_op_str(
-                    &vm.get(inst.arg0),
-                    &vm.get(inst.arg1),
+                    &self.get(inst.arg0),
+                    &self.get(inst.arg1),
                     |lhs, rhs| Ok(lhs + rhs),
                     |lhs, rhs| lhs + rhs,
                     |lhs: &str, rhs: &str| Ok(lhs.to_string() + rhs),
                 )?;
-                vm.set(inst.arg0, result);
+                self.set(inst.arg0, result);
             }
             OpCode::Sub => {
                 let result = binary_op(
-                    &vm.get(inst.arg0),
-                    &vm.get(inst.arg1),
+                    &self.get(inst.arg0),
+                    &self.get(inst.arg1),
                     |lhs, rhs| lhs - rhs,
                     |lhs, rhs| lhs - rhs,
                 )?;
-                vm.set(inst.arg0, result);
+                self.set(inst.arg0, result);
             }
             OpCode::Mul => {
                 let result = binary_op(
-                    &vm.get(inst.arg0),
-                    &vm.get(inst.arg1),
+                    &self.get(inst.arg0),
+                    &self.get(inst.arg1),
                     |lhs, rhs| lhs * rhs,
                     |lhs, rhs| lhs * rhs,
                 )?;
-                vm.set(inst.arg0, result);
+                self.set(inst.arg0, result);
             }
             OpCode::Div => {
                 let result = binary_op(
-                    &vm.get(inst.arg0),
-                    &vm.get(inst.arg1),
+                    &self.get(inst.arg0),
+                    &self.get(inst.arg1),
                     |lhs, rhs| lhs / rhs,
                     |lhs, rhs| lhs / rhs,
                 )?;
-                vm.set(inst.arg0, result);
+                self.set(inst.arg0, result);
             }
             OpCode::BitAnd => {
                 let result =
-                    binary_op_int(&vm.get(inst.arg0), &vm.get(inst.arg1), |lhs, rhs| lhs & rhs)?;
-                vm.set(inst.arg0, result);
+                    binary_op_int(&self.get(inst.arg0), &self.get(inst.arg1), |lhs, rhs| {
+                        lhs & rhs
+                    })?;
+                self.set(inst.arg0, result);
             }
             OpCode::BitXor => {
                 let result =
-                    binary_op_int(&vm.get(inst.arg0), &vm.get(inst.arg1), |lhs, rhs| lhs ^ rhs)?;
-                vm.set(inst.arg0, result);
+                    binary_op_int(&self.get(inst.arg0), &self.get(inst.arg1), |lhs, rhs| {
+                        lhs ^ rhs
+                    })?;
+                self.set(inst.arg0, result);
             }
             OpCode::BitOr => {
                 let result =
-                    binary_op_int(&vm.get(inst.arg0), &vm.get(inst.arg1), |lhs, rhs| lhs | rhs)?;
-                vm.set(inst.arg0, result);
+                    binary_op_int(&self.get(inst.arg0), &self.get(inst.arg1), |lhs, rhs| {
+                        lhs | rhs
+                    })?;
+                self.set(inst.arg0, result);
             }
             OpCode::And => {
-                let result = truthy(&vm.get(inst.arg0)) && truthy(&vm.get(inst.arg1));
-                vm.set(inst.arg0, Value::I32(result as i32));
+                let result = truthy(&self.get(inst.arg0)) && truthy(&self.get(inst.arg1));
+                self.set(inst.arg0, Value::I32(result as i32));
             }
             OpCode::Or => {
-                let result = truthy(&vm.get(inst.arg0)) || truthy(&vm.get(inst.arg1));
-                vm.set(inst.arg0, Value::I32(result as i32));
+                let result = truthy(&self.get(inst.arg0)) || truthy(&self.get(inst.arg1));
+                self.set(inst.arg0, Value::I32(result as i32));
             }
             OpCode::Not => {
-                let result = !truthy(&vm.get(inst.arg0));
-                vm.set(inst.arg0, Value::I32(result as i32));
+                let result = !truthy(&self.get(inst.arg0));
+                self.set(inst.arg0, Value::I32(result as i32));
             }
             OpCode::BitNot => {
-                let val = vm.get(inst.arg0);
+                let val = self.get(inst.arg0);
                 let result = match val {
                     Value::I32(i) => Value::I32(!i),
                     Value::I64(i) => Value::I64(!i),
                     _ => return Err(EvalError::NonIntegerBitwise(format!("{val:?}"))),
                 };
-                vm.set(inst.arg0, result);
+                self.set(inst.arg0, result);
             }
             OpCode::Get => {
-                let target_collection = &vm.get(inst.arg0);
-                let target_index = &vm.get(inst.arg1);
+                let target_collection = &self.get(inst.arg0);
+                let target_index = &self.get(inst.arg1);
                 let index = coerce_i64(target_index)? as u64;
                 let new_val = target_collection.array_get(index).or_else(|_| {
                     target_collection.tuple_get(index)
                 }).map_err(|e| {
                     format!("Get instruction failed with {target_collection:?} and {target_index:?}: {e:?}")
                 })?;
-                vm.set(inst.arg1, new_val);
+                self.set(inst.arg1, new_val);
             }
             OpCode::Set => {
-                let target_collection = &vm.get(inst.arg0);
-                let value = vm.get(inst.arg1);
-                let index = vm.set_register;
+                let target_collection = &self.get(inst.arg0);
+                let value = self.get(inst.arg1);
+                let index = self.set_register;
                 target_collection.array_assign(index, value.clone())?;
             }
             OpCode::SetReg => {
-                vm.set_register = coerce_i64(vm.get(inst.arg0 as usize))? as usize;
+                self.set_register = coerce_i64(self.get(inst.arg0 as usize))? as usize;
             }
             OpCode::Lt => {
                 let result = compare_op(
-                    &vm.get(inst.arg0),
-                    &vm.get(inst.arg1),
+                    &self.get(inst.arg0),
+                    &self.get(inst.arg1),
                     |lhs, rhs| lhs.lt(&rhs),
                     |lhs, rhs| lhs.lt(&rhs),
                 )?;
-                vm.set(inst.arg0, Value::I64(result as i64));
+                self.set(inst.arg0, Value::I64(result as i64));
             }
             OpCode::Gt => {
                 let result = compare_op(
-                    &vm.get(inst.arg0),
-                    &vm.get(inst.arg1),
+                    &self.get(inst.arg0),
+                    &self.get(inst.arg1),
                     |lhs, rhs| lhs.gt(&rhs),
                     |lhs, rhs| lhs.gt(&rhs),
                 )?;
-                vm.set(inst.arg0, Value::I64(result as i64));
+                self.set(inst.arg0, Value::I64(result as i64));
             }
             OpCode::Jmp => {
                 dbg_println!("[{ip}] Jumping by Jmp to {}", inst.arg1);
-                call_stack.clast_mut()?.ip = inst.arg1 as usize;
-                continue;
+                self.call_stack.clast_mut()?.ip = inst.arg1 as usize;
+                return Ok(None);
             }
             OpCode::Jt => {
-                if truthy(&vm.get(inst.arg0)) {
+                if truthy(&self.get(inst.arg0)) {
                     dbg_println!("[{ip}] Jumping by Jt to {}", inst.arg1);
-                    call_stack.clast_mut()?.ip = inst.arg1 as usize;
-                    continue;
+                    self.call_stack.clast_mut()?.ip = inst.arg1 as usize;
+                    return Ok(None);
                 }
             }
             OpCode::Jf => {
-                if !truthy(&vm.get(inst.arg0)) {
+                if !truthy(&self.get(inst.arg0)) {
                     dbg_println!("[{ip}] Jumping by Jf to {}", inst.arg1);
-                    call_stack.clast_mut()?.ip = inst.arg1 as usize;
-                    continue;
+                    self.call_stack.clast_mut()?.ip = inst.arg1 as usize;
+                    return Ok(None);
                 }
             }
             OpCode::Call => {
-                let arg_name = vm.get(inst.arg1);
+                let arg_name = self.get(inst.arg1);
                 let arg_name = if let Value::Str(s) = arg_name {
                     s
                 } else {
                     return Err(EvalError::NonNameFnRef(format!("{arg_name:?}")));
                 };
-                let fun = functions.iter().find(|(fname, _)| *fname == arg_name);
+                let fun = self.functions.iter().find(|(fname, _)| *fname == arg_name);
                 if let Some((_, fun)) = fun {
                     match fun {
                         FnProto::Code(fun) => {
                             dbg_println!("Calling code function with stack size (base:{}) + (fn: 1) + (params: {}) + (cur stack:{})", inst.arg1, inst.arg0, fun.stack_size);
                             // +1 for function name and return slot
-                            vm.stack_base += inst.arg1 as usize;
-                            vm.stack.resize(
-                                vm.stack_base + inst.arg0 as usize + fun.stack_size + 1,
+                            self.stack_base += inst.arg1 as usize;
+                            self.stack.resize(
+                                self.stack_base + inst.arg0 as usize + fun.stack_size + 1,
                                 Value::default(),
                             );
-                            call_stack.push(CallInfo {
+                            self.call_stack.push(CallInfo {
                                 fun,
                                 ip: 0,
-                                stack_size: vm.stack.len(),
-                                stack_base: vm.stack_base,
+                                stack_size: self.stack.len(),
+                                stack_base: self.stack_base,
                             });
-                            continue;
+                            return Ok(None);
                         }
                         FnProto::Native(nat) => {
-                            let ret = nat(&vm.slice(
+                            let ret = nat(&self.slice(
                                 inst.arg1 as usize + 1,
                                 inst.arg1 as usize + 1 + inst.arg0 as usize,
                             ));
-                            vm.set(inst.arg1, ret?);
+                            self.set(inst.arg1, ret?);
                         }
                     }
                 } else {
@@ -345,40 +384,42 @@ fn interpret_fn(
                 }
             }
             OpCode::Ret => {
-                let retval = vm.stack_base + inst.arg1 as usize;
-                if let Some(prev_ci) = call_stack.pop() {
-                    if call_stack.is_empty() {
-                        return Ok(vm.get(inst.arg1).clone());
+                let retval = self.stack_base + inst.arg1 as usize;
+                if let Some(prev_ci) = self.call_stack.pop() {
+                    if self.call_stack.is_empty() {
+                        return Ok(Some(self.get(inst.arg1).clone()));
                     } else {
-                        let ci = call_stack.clast()?;
-                        vm.stack_base = ci.stack_base;
-                        vm.stack[prev_ci.stack_base] = vm.stack[retval].clone();
-                        vm.stack.resize(ci.stack_size, Value::default());
-                        vm.dump_stack();
+                        let ci = self.call_stack.clast()?;
+                        self.stack_base = ci.stack_base;
+                        self.stack[prev_ci.stack_base] = self.stack[retval].clone();
+                        self.stack.resize(ci.stack_size, Value::default());
+                        self.dump_stack();
                     }
                 } else {
                     return Err(EvalError::CallStackUndeflow);
                 }
             }
             OpCode::Cast => {
-                let target_var = &vm.get(inst.arg0);
-                let target_type = coerce_i64(vm.get(inst.arg1))
+                let target_var = &self.get(inst.arg0);
+                let target_type = coerce_i64(self.get(inst.arg1))
                     .map_err(|e| format!("arg1 of Cast was not a number: {e:?}"))?;
                 let tt_buf = target_type.to_le_bytes();
                 let tt = TypeDecl::deserialize(&mut &tt_buf[..])
                     .map_err(|e| format!("arg1 of Cast was not a TypeDecl: {e:?}"))?;
                 let new_val = coerce_type(target_var, &tt)?;
-                vm.set(inst.arg0, new_val);
+                self.set(inst.arg0, new_val);
             }
         }
 
-        vm.dump_stack();
+        self.dump_stack();
 
-        call_stack.clast_mut()?.ip += 1;
+        self.call_stack.clast_mut()?.ip += 1;
+
+        Ok(None)
     }
 
-    dbg_println!("Final stack: {:?}", vm.stack);
-    Ok(Value::I64(0))
+    // dbg_println!("Final stack: {:?}", self.stack);
+    // Ok(Some(Value::I64(0))
 }
 
 fn compare_op(

--- a/parser/src/vm.rs
+++ b/parser/src/vm.rs
@@ -177,7 +177,7 @@ impl<'a> Vm<'a> {
 
     pub fn deepclone(&self) -> Self {
         Self {
-            stack: self.stack.iter().map(|v| v.clone()).collect(),
+            stack: self.stack.iter().map(|v| v.deepclone()).collect(),
             stack_base: self.stack_base,
             call_stack: self.call_stack.clone(),
             set_register: self.set_register,

--- a/parser/src/vm.rs
+++ b/parser/src/vm.rs
@@ -35,6 +35,10 @@ pub struct CallInfo<'a> {
 }
 
 impl<'a> CallInfo<'a> {
+    pub fn bytecode(&self) -> &'a FnBytecode {
+        self.fun
+    }
+
     pub fn instuction_ptr(&self) -> usize {
         self.ip
     }

--- a/parser/src/vm.rs
+++ b/parser/src/vm.rs
@@ -27,6 +27,7 @@ pub fn interpret(bytecode: &Bytecode) -> Result<Value, EvalError> {
     }
 }
 
+#[derive(Clone)]
 pub struct CallInfo<'a> {
     fun: &'a FnBytecode,
     ip: usize,
@@ -48,6 +49,7 @@ impl<'a> CallInfo<'a> {
     }
 }
 
+#[derive(Clone)]
 /// The virtual machine state run by the bytecode.
 /// Now it is a full state machine that has complete information to suspend and resume at any time,
 /// given that the lifetime of the functions are valid.

--- a/parser/src/vm.rs
+++ b/parser/src/vm.rs
@@ -49,7 +49,6 @@ impl<'a> CallInfo<'a> {
     }
 }
 
-#[derive(Clone)]
 /// The virtual machine state run by the bytecode.
 /// Now it is a full state machine that has complete information to suspend and resume at any time,
 /// given that the lifetime of the functions are valid.
@@ -173,6 +172,16 @@ impl<'a> Vm<'a> {
             writeln!(f, "  [{i}] {value}")?;
         }
         Ok(())
+    }
+
+    pub fn deepclone(&self) -> Self {
+        Self {
+            stack: self.stack.iter().map(|v| v.clone()).collect(),
+            stack_base: self.stack_base,
+            call_stack: self.call_stack.clone(),
+            set_register: self.set_register,
+            functions: self.functions,
+        }
     }
 }
 

--- a/parser/src/vm.rs
+++ b/parser/src/vm.rs
@@ -152,6 +152,17 @@ impl<'a> Vm<'a> {
         }
         Ok(())
     }
+
+    pub fn print_stack(&self, f: &mut impl Write) -> std::io::Result<()> {
+        let Some(ci) = self.call_stack.last() else {
+            // Empty call stack is not an error
+            return Ok(());
+        };
+        for (i, value) in self.stack[ci.stack_base..ci.stack_size].iter().enumerate() {
+            writeln!(f, "  [{i}] {value}")?;
+        }
+        Ok(())
+    }
 }
 
 /// An extension trait for `Vec` to write a shorthand for

--- a/parser/src/vm/test.rs
+++ b/parser/src/vm/test.rs
@@ -17,25 +17,31 @@ fn compile_expr(s: &str) -> Bytecode {
 
 #[test]
 fn eval_test() {
-    assert_eq!(interpret(&compile_expr(" 1 +  2 ")), Ok(Value::I64(3)));
+    assert_eq!(interpret(&compile_expr(" 1 +  2 ")).unwrap(), Value::I64(3));
     assert_eq!(
-        interpret(&compile_expr(" 12 + 6 - 4+  3")),
-        Ok(Value::I64(17))
+        interpret(&compile_expr(" 12 + 6 - 4+  3")).unwrap(),
+        Value::I64(17)
     );
-    assert_eq!(interpret(&compile_expr(" 1 + 2*3 + 4")), Ok(Value::I64(11)));
-    assert_eq!(interpret(&compile_expr(" 1 +  2.5 ")), Ok(Value::F64(3.5)));
+    assert_eq!(
+        interpret(&compile_expr(" 1 + 2*3 + 4")).unwrap(),
+        Value::I64(11)
+    );
+    assert_eq!(
+        interpret(&compile_expr(" 1 +  2.5 ")).unwrap(),
+        Value::F64(3.5)
+    );
 }
 
 #[test]
 fn parens_eval_test() {
-    assert_eq!(interpret(&compile_expr(" (  2 )")), Ok(Value::I64(2)));
+    assert_eq!(interpret(&compile_expr(" (  2 )")).unwrap(), Value::I64(2));
     assert_eq!(
-        interpret(&compile_expr(" 2* (  3 + 4 ) ")),
-        Ok(Value::I64(14))
+        interpret(&compile_expr(" 2* (  3 + 4 ) ")).unwrap(),
+        Value::I64(14)
     );
     assert_eq!(
-        interpret(&compile_expr("  2*2 / ( 5 - 1) + 3")),
-        Ok(Value::I64(4))
+        interpret(&compile_expr("  2*2 / ( 5 - 1) + 3")).unwrap(),
+        Value::I64(4)
     );
 }
 
@@ -46,81 +52,84 @@ fn compile_and_run(src: &str) -> Result<Value, EvalError> {
 #[test]
 fn var_test() {
     assert_eq!(
-        compile_and_run("var x = 42.; x +  2; "),
-        Ok(Value::F64(44.))
+        compile_and_run("var x = 42.; x +  2; ").unwrap(),
+        Value::F64(44.)
     );
 }
 
 #[test]
 fn var_assign_test() {
-    assert_eq!(compile_and_run("var x = 42.; x=12"), Ok(Value::I64(12)));
+    assert_eq!(
+        compile_and_run("var x = 42.; x=12").unwrap(),
+        Value::I64(12)
+    );
 }
 
 #[test]
 fn cond_test() {
-    assert_eq!(compile_and_run("if 0 { 1; }"), Ok(Value::I64(0)));
+    assert_eq!(compile_and_run("if 0 { 1; }").unwrap(), Value::I64(0));
     assert_eq!(
-        compile_and_run("if (1) { 2; } else { 3; }"),
-        Ok(Value::I64(2))
+        compile_and_run("if (1) { 2; } else { 3; }").unwrap(),
+        Value::I64(2)
     );
     assert_eq!(
-        compile_and_run("if 1 && 2 { 2; } else { 3; }"),
-        Ok(Value::I64(2))
+        compile_and_run("if 1 && 2 { 2; } else { 3; }").unwrap(),
+        Value::I64(2)
     );
 }
 
 #[test]
 fn cmp_eval_test() {
-    assert_eq!(compile_and_run(" 1 <  2 "), Ok(Value::I64(1)));
-    assert_eq!(compile_and_run(" 1 > 2"), Ok(Value::I64(0)));
-    assert_eq!(compile_and_run(" 2 < 1"), Ok(Value::I64(0)));
-    assert_eq!(compile_and_run(" 2 > 1"), Ok(Value::I64(1)));
+    assert_eq!(compile_and_run(" 1 <  2 ").unwrap(), Value::I64(1));
+    assert_eq!(compile_and_run(" 1 > 2").unwrap(), Value::I64(0));
+    assert_eq!(compile_and_run(" 2 < 1").unwrap(), Value::I64(0));
+    assert_eq!(compile_and_run(" 2 > 1").unwrap(), Value::I64(1));
 }
 
 #[test]
 fn bit_op_test() {
-    assert_eq!(compile_and_run(" 0 & 1 "), Ok(Value::I64(0)));
-    assert_eq!(compile_and_run(" 0 | 1 "), Ok(Value::I64(1)));
-    assert_eq!(compile_and_run(" 1 & 0 | 1 "), Ok(Value::I64(1)));
-    assert_eq!(compile_and_run(" 1 & 0 | 0 "), Ok(Value::I64(0)));
-    assert_eq!(compile_and_run(" 1 & !0 "), Ok(Value::I64(1)));
-    assert_eq!(compile_and_run(" 1 ^ 2 "), Ok(Value::I64(3)));
-    assert_eq!(compile_and_run(" 3 ^ 2 "), Ok(Value::I64(1)));
+    assert_eq!(compile_and_run(" 0 & 1 ").unwrap(), Value::I64(0));
+    assert_eq!(compile_and_run(" 0 | 1 ").unwrap(), Value::I64(1));
+    assert_eq!(compile_and_run(" 1 & 0 | 1 ").unwrap(), Value::I64(1));
+    assert_eq!(compile_and_run(" 1 & 0 | 0 ").unwrap(), Value::I64(0));
+    assert_eq!(compile_and_run(" 1 & !0 ").unwrap(), Value::I64(1));
+    assert_eq!(compile_and_run(" 1 ^ 2 ").unwrap(), Value::I64(3));
+    assert_eq!(compile_and_run(" 3 ^ 2 ").unwrap(), Value::I64(1));
 }
 
 #[test]
 fn logic_eval_test() {
-    assert_eq!(compile_and_run(" 0 && 1 "), Ok(Value::I32(0)));
-    assert_eq!(compile_and_run(" 0 || 1 "), Ok(Value::I32(1)));
-    assert_eq!(compile_and_run(" 1 && 0 || 1 "), Ok(Value::I32(1)));
-    assert_eq!(compile_and_run(" 1 && 0 || 0 "), Ok(Value::I32(0)));
-    assert_eq!(compile_and_run(" 1 && !0 "), Ok(Value::I32(1)));
+    assert_eq!(compile_and_run(" 0 && 1 ").unwrap(), Value::I32(0));
+    assert_eq!(compile_and_run(" 0 || 1 ").unwrap(), Value::I32(1));
+    assert_eq!(compile_and_run(" 1 && 0 || 1 ").unwrap(), Value::I32(1));
+    assert_eq!(compile_and_run(" 1 && 0 || 0 ").unwrap(), Value::I32(0));
+    assert_eq!(compile_and_run(" 1 && !0 ").unwrap(), Value::I32(1));
 }
 
 #[test]
 fn brace_expr_eval_test() {
-    assert_eq!(compile_and_run(" { 1; } "), Ok(Value::I64(1)));
-    assert_eq!(compile_and_run(" { 1; 2 }"), Ok(Value::I64(2)));
-    assert_eq!(compile_and_run(" {1; 2;} "), Ok(Value::I64(2)));
+    assert_eq!(compile_and_run(" { 1; } ").unwrap(), Value::I64(1));
+    assert_eq!(compile_and_run(" { 1; 2 }").unwrap(), Value::I64(2));
+    assert_eq!(compile_and_run(" {1; 2;} ").unwrap(), Value::I64(2));
     assert_eq!(
-        compile_and_run("  { var x: i64 = 10; x = 20; x } "),
-        Ok(Value::I64(20))
+        compile_and_run("  { var x: i64 = 10; x = 20; x } ").unwrap(),
+        Value::I64(20)
     );
 }
 
 #[test]
 fn brace_shadowing_test() {
     assert_eq!(
-        compile_and_run(" var x = 0; { var x = 1; }; x;"),
-        Ok(Value::I64(0))
+        compile_and_run(" var x = 0; { var x = 1; }; x;").unwrap(),
+        Value::I64(0)
     );
     assert_eq!(
-        compile_and_run(" var x = 0; { var x = 1; x; };"),
-        Ok(Value::I64(1))
+        compile_and_run(" var x = 0; { var x = 1; x; };").unwrap(),
+        Value::I64(1)
     );
     assert_eq!(
-        compile_and_run(" var x = 0; { var x = 1; x = 2; }; x;"),
-        Ok(Value::I64(0))
+        compile_and_run(" var x = 0; { var x = 1; x = 2; }; x;").unwrap(),
+        Value::I64(0)
     );
 }
 

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{cell::RefCell, collections::HashMap, rc::Rc};
 
 use mascal::*;
 use wasm_bindgen::prelude::*;
@@ -191,7 +191,11 @@ pub fn compile_and_run(src: &str) -> Result<(), JsValue> {
     });
     let mut bytecode = mascal::compile(&parse_result.1, functions)
         .map_err(|e| JsValue::from_str(&format!("Error: {}", e)))?;
-    bytecode.add_std_fn();
+
+    // Give a sink because we don't care (can't care) where to put the output from standard functions.
+    // Instead, we override the functions with Wasm aware versions.
+    bytecode.add_std_fn(Rc::new(RefCell::new(std::io::sink())));
+
     extra_functions(&mut |name, f| {
         bytecode.add_ext_fn(name, f);
     });


### PR DESCRIPTION
# Overview

One of the hardest things in developing your own bytecode is to debug when something is going wrong in the bytecode interpreter, so we would like to have a text based interactive debugger, similar to the graphical mode of gdb.

![image](https://github.com/user-attachments/assets/400ac8a8-8eab-425e-aaae-6523900ba177)

It doesn't have much functionality, but it's a start.
It can step each instruction, disassembly the instructions, show the current stack values and show stack trace (call stacks).

On top of that, it has a time-travel debugger, which lets you go back in time and see the previous state of the VM.
It is quite powerful tool, but since it can consume so much memory, the history to go back is limited to 100 steps. It could be serialized into a file and inspected offline in the future to mitigate the memory requirement.

https://github.com/user-attachments/assets/9d0fa512-bc8e-4146-9b26-62b92b76a83c

## Help window

It also has friendly debug window to show keyboard shortcuts, which is always available by hitting H key.

![image](https://github.com/user-attachments/assets/a767ac16-23e8-4448-9bb2-29912527ae35)

# Implementation

We use Ratatui to implement TUI.

## Why not GUI? Web UI? Or LSP?

Native GUI is often used for natively compiled executables (obviously), but it has a lot of complexities that closely tied to the platform which I don't want to deal with at this moment.

Desktop GUI frameworks using web technologies such as Tauri can be useful, but it's kind of overkill to implement a web server in a interpreter.

LSP does not natively support debugging. There is another API spec for [debugging protocol](https://kichwacoders.com/2017/11/08/debug-protocol-vs-language-server-protocol/), but it's more complicated, designed for native languages and not necessarily works well with custom bytecode.

# Known issues

* [x] ~Sine Ratatui uses standard output to show the TUI, it conflicts with the standard output from the script's `print` or `puts` built-in funcitions. They should be redirected to a buffer and shown in a widget.~ Fixed!
* [x] Arrays share the internal buffer with `Rc<RefCell<Value>>`, which should be un-shared when we make a history snapshot of `Vm`. However, it is not as easy as it sounds. First, I tried to implement `deepcopy()` method to all types in the VM, which is easy, but if you actually use it, it will unlink not only the buffers between different time steps of VM but also the buffer in the same VM. It will turn a reference semantics to value semantics, which changes the behavior of the code!
