### PR TITLE
Source listing in the interactive debugger

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -318,6 +318,7 @@ dependencies = [
  "clap",
  "colored",
  "mascal",
+ "nom",
  "ratatui",
 ]
 
@@ -348,9 +349,9 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.1"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -11,5 +11,6 @@ mascal = { path = "../parser" }
 clap = { version = "3.2.22", features = ["derive"] }
 colored = "2.0.0"
 ratatui = "0.28.1"
+nom = "7.1.3"
 
 

--- a/cli/src/debugger.rs
+++ b/cli/src/debugger.rs
@@ -52,6 +52,7 @@ struct App<'a> {
 
 enum WidgetFocus {
     SourceList,
+    Stack,
     Disasm,
 }
 
@@ -280,11 +281,19 @@ impl<'a> App<'a> {
                         WidgetFocus::SourceList => {
                             self.widgets.source_list.focus = false;
                             self.widgets.disasm.as_mut().map(|d| d.focus = true);
+                            self.widgets.stack.as_mut().map(|d| d.focus = false);
                             WidgetFocus::Disasm
                         }
                         WidgetFocus::Disasm => {
+                            self.widgets.source_list.focus = false;
+                            self.widgets.disasm.as_mut().map(|d| d.focus = false);
+                            self.widgets.stack.as_mut().map(|d| d.focus = true);
+                            WidgetFocus::Stack
+                        }
+                        WidgetFocus::Stack => {
                             self.widgets.source_list.focus = true;
                             self.widgets.disasm.as_mut().map(|d| d.focus = false);
+                            self.widgets.stack.as_mut().map(|d| d.focus = false);
                             WidgetFocus::SourceList
                         }
                     }
@@ -296,6 +305,9 @@ impl<'a> App<'a> {
                             da.update_scroll(-1)
                         }
                     }
+                    WidgetFocus::Stack => {
+                        self.widgets.stack.as_mut().map(|d| d.update_scroll(-1));
+                    }
                 },
                 (KeyEventKind::Press, KeyCode::Down) => match self.widgets.focus {
                     WidgetFocus::SourceList => self.widgets.source_list.update_scroll(1),
@@ -303,6 +315,9 @@ impl<'a> App<'a> {
                         if let Some(ref mut da) = self.widgets.disasm {
                             da.update_scroll(1)
                         }
+                    }
+                    WidgetFocus::Stack => {
+                        self.widgets.stack.as_mut().map(|d| d.update_scroll(1));
                     }
                 },
                 _ => {}

--- a/cli/src/debugger.rs
+++ b/cli/src/debugger.rs
@@ -278,7 +278,7 @@ impl<'a> App<'a> {
                         self.exit = true;
                     }
                 }
-                (KeyEventKind::Release, KeyCode::Tab) => {
+                (KeyEventKind::Press, KeyCode::Tab) => {
                     // TODO: how to pick up Shift+Tab event?
                     self.widgets.focus = if key.modifiers.contains(KeyModifiers::SHIFT) {
                         match self.widgets.focus {

--- a/cli/src/debugger.rs
+++ b/cli/src/debugger.rs
@@ -310,12 +310,12 @@ impl Widgets {
         &mut self,
         vm: &Vm,
         level: usize,
-        debug: &DebugInfo,
+        debug: Option<&DebugInfo>,
         output_buffer: &Rc<RefCell<Vec<u8>>>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         if let Some(ref mut disasm) = self.disasm {
             if let Some(ci) = vm.call_info(level) {
-                let debug_fn = debug.get(ci.bytecode().name());
+                let debug_fn = debug.and_then(|debug| debug.get(ci.bytecode().name()));
                 disasm.update(ci.bytecode(), ci.instuction_ptr(), debug_fn.map(|v| &v[..]))?;
             }
         }

--- a/cli/src/debugger.rs
+++ b/cli/src/debugger.rs
@@ -13,7 +13,7 @@ use ratatui::{
     buffer::Buffer,
     crossterm::event::{self, KeyCode, KeyEventKind, KeyModifiers},
     layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::Stylize,
+    style::{Style, Stylize},
     symbols::border,
     text::{Line, Text},
     widgets::{
@@ -402,7 +402,11 @@ impl<'a> Widget for &mut App<'a> {
         let instructions = Title::from(Line::from(vec![
             "  help: ".into(),
             "h".blue().bold(),
-            "  quit: ".into(),
+            if matches!(self.mode, AppMode::StepRun { .. }) {
+                "  stop running program: ".into()
+            } else {
+                "  quit: ".into()
+            },
             "q ".blue().bold(),
         ]));
         let block = Block::bordered()
@@ -412,6 +416,11 @@ impl<'a> Widget for &mut App<'a> {
                     .alignment(Alignment::Center)
                     .position(Position::Bottom),
             )
+            .border_style(if matches!(self.mode, AppMode::StepRun { .. }) {
+                Style::new().light_yellow()
+            } else {
+                Style::new()
+            })
             .border_set(border::THICK);
 
         let layout = Layout::default()

--- a/cli/src/debugger/disasm.rs
+++ b/cli/src/debugger/disasm.rs
@@ -3,23 +3,33 @@ use ratatui::{
     buffer::Buffer,
     layout::{Alignment, Rect},
     style::{Style, Stylize},
-    symbols::border,
+    symbols::{border, scrollbar},
     text::{Line, Text},
-    widgets::{block::Title, Block, Paragraph, Widget},
+    widgets::{
+        block::Title, Block, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState,
+        StatefulWidget, Widget,
+    },
 };
 
 pub(super) struct DisasmWidget {
-    pub(super) text: String,
-    pub(super) scroll: usize,
+    text: String,
+    scroll: usize,
+    scroll_state: ScrollbarState,
+    /// Cached height of rendered text area. Used for calculating scroll position.
+    render_height: u16,
 }
 
 impl DisasmWidget {
     pub(super) fn new(bytecode: &Bytecode) -> Result<Self, Box<dyn std::error::Error>> {
         let mut temp = vec![];
         bytecode.disasm(&mut temp)?;
+        let text = String::from_utf8(temp)?;
+        let length = text.chars().filter(|c| *c == '\n').count();
         Ok(Self {
-            text: String::from_utf8(temp)?,
+            text,
             scroll: 0,
+            scroll_state: ScrollbarState::new(length),
+            render_height: 10,
         })
     }
 
@@ -30,6 +40,7 @@ impl DisasmWidget {
         debug: Option<&[LineInfo]>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let mut temp = String::new();
+        let mut lines = 0;
         for (i, inst) in bytecode.iter_instructions().enumerate() {
             let current = if i == ip { "*" } else { " " };
             let line_num = debug.map_or_else(
@@ -44,14 +55,29 @@ impl DisasmWidget {
                 },
             );
             temp += &format!("{current}  {} [{}] {}\n", line_num, i, inst);
+            lines += 1;
         }
         self.text = temp;
-        self.scroll = ip.saturating_sub(3); // Leave 3 lines before
+        // When the instruction pointer moves by stepping the program, we want to follow its position.
+        self.scroll = self.scroll.clamp(
+            (ip + 3).saturating_sub(self.render_height as usize),
+            ip.saturating_sub(3),
+        ); // Leave 3 lines before
+        self.scroll_state = ScrollbarState::new(lines).position(self.scroll);
         Ok(())
+    }
+
+    pub(super) fn update_scroll(&mut self, delta: i32) {
+        if delta < 0 {
+            self.scroll = self.scroll.saturating_sub(delta.abs() as usize);
+        } else {
+            self.scroll = self.scroll.saturating_add(delta as usize);
+        }
+        self.scroll_state = self.scroll_state.position(self.scroll);
     }
 }
 
-impl Widget for &DisasmWidget {
+impl Widget for &mut DisasmWidget {
     fn render(self, area: Rect, buf: &mut Buffer)
     where
         Self: Sized,
@@ -69,8 +95,19 @@ impl Widget for &DisasmWidget {
             lines.extend(text_lines[self.scroll..].iter().map(|v| Line::from(*v)));
         }
 
+        let sbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
+            .symbols(scrollbar::VERTICAL)
+            .begin_symbol(None)
+            .track_symbol(None)
+            .end_symbol(None);
+        let inner = block.inner(area);
+
         Paragraph::new(Text::from(lines))
             .block(block)
             .render(area, buf);
+
+        sbar.render(inner, buf, &mut self.scroll_state);
+
+        self.render_height = inner.height;
     }
 }

--- a/cli/src/debugger/disasm.rs
+++ b/cli/src/debugger/disasm.rs
@@ -50,10 +50,8 @@ impl DisasmWidget {
                 |debug| {
                     debug
                         .iter()
-                        .find(|line_info| {
-                            line_info.byte_start <= (i as u32) && (i as u32) <= line_info.byte_end
-                        })
-                        .map_or_else(|| "    ".to_string(), |li| format!("{:04}", li.src_start))
+                        .find(|line_info: &&LineInfo| line_info.instruction == (i as u32))
+                        .map_or_else(|| "    ".to_string(), |li| format!("{:04}", li.src_line))
                 },
             );
             temp += &format!("{current}  {} [{}] {}\n", line_num, i, inst);

--- a/cli/src/debugger/disasm.rs
+++ b/cli/src/debugger/disasm.rs
@@ -17,6 +17,7 @@ pub(super) struct DisasmWidget {
     scroll_state: ScrollbarState,
     /// Cached height of rendered text area. Used for calculating scroll position.
     render_height: u16,
+    pub(super) focus: bool,
 }
 
 impl DisasmWidget {
@@ -30,6 +31,7 @@ impl DisasmWidget {
             scroll: 0,
             scroll_state: ScrollbarState::new(length),
             render_height: 10,
+            focus: false,
         })
     }
 
@@ -88,7 +90,11 @@ impl Widget for &mut DisasmWidget {
         let block = Block::bordered()
             .title(title.alignment(Alignment::Center))
             .border_style(Style::new().yellow())
-            .border_set(border::THICK);
+            .border_set(if self.focus {
+                border::THICK
+            } else {
+                border::PLAIN
+            });
 
         let mut lines = vec![];
         if self.scroll < text_lines.len() {

--- a/cli/src/debugger/disasm.rs
+++ b/cli/src/debugger/disasm.rs
@@ -1,5 +1,3 @@
-use std::cmp::Ordering;
-
 use mascal::{Bytecode, FnBytecode, LineInfo};
 use ratatui::{
     buffer::Buffer,
@@ -38,20 +36,11 @@ impl DisasmWidget {
                 || "   ".to_string(),
                 |debug| {
                     debug
-                        .binary_search_by(|line_info| {
-                            if (i as u32) < line_info.byte_start {
-                                Ordering::Less
-                            } else if line_info.byte_end <= (i as u32) {
-                                Ordering::Greater
-                            } else {
-                                Ordering::Equal
-                            }
+                        .iter()
+                        .find(|line_info| {
+                            line_info.byte_start <= (i as u32) && (i as u32) <= line_info.byte_end
                         })
-                        .map_or_else(
-                            |i| debug.get(i).map(|li| li.src_start),
-                            |i| debug.get(i).map(|li| li.src_start),
-                        )
-                        .map_or_else(|| "    ".to_string(), |line| format!("{line:04}"))
+                        .map_or_else(|| "    ".to_string(), |li| format!("{:04}", li.src_start))
                 },
             );
             temp += &format!("{current}  {} [{}] {}\n", line_num, i, inst);

--- a/cli/src/debugger/help.rs
+++ b/cli/src/debugger/help.rs
@@ -33,6 +33,18 @@ impl Widget for &HelpWidget {
                 "k".blue().bold(),
             ]),
             Line::from(vec!["  Toggle output widget: ".into(), "o".blue().bold()]),
+            Line::from(vec![
+                "  Change widget focus to scroll: ".into(),
+                "Tab".blue().bold(),
+            ]),
+            Line::from(vec![
+                "  Scroll up current widget: ".into(),
+                "up".blue().bold(),
+            ]),
+            Line::from(vec![
+                "  Scroll down current widget: ".into(),
+                "down".blue().bold(),
+            ]),
             Line::from(vec!["  run current code: ".into(), "r".blue().bold()]),
             Line::from(vec!["  Step execution mode: ".into(), "s".blue().bold()]),
             Line::from(vec!["  Move up stack frame: ".into(), "u".blue().bold()]),

--- a/cli/src/debugger/help.rs
+++ b/cli/src/debugger/help.rs
@@ -57,7 +57,10 @@ impl Widget for &HelpWidget {
                 "  Next state in time travel debugger: ".into(),
                 "n".blue().bold(),
             ]),
-            Line::from(vec!["  quit: ".into(), "q ".blue().bold()]),
+            Line::from(vec![
+                "  quit or stop current debugging session: ".into(),
+                "q ".blue().bold(),
+            ]),
         ]);
         let title = Title::from(" Help ".bold());
         let block = Block::bordered()

--- a/cli/src/debugger/help.rs
+++ b/cli/src/debugger/help.rs
@@ -4,7 +4,7 @@ use ratatui::{
     style::{Color, Style, Stylize},
     symbols::border,
     text::{Line, Text},
-    widgets::{block::Title, Block, Paragraph, Widget},
+    widgets::{block::Title, Block, Clear, Paragraph, Widget},
 };
 
 pub(super) struct HelpWidget {}
@@ -54,6 +54,8 @@ impl Widget for &HelpWidget {
             .style(Style::default().bg(Color::DarkGray))
             .border_style(Style::new().white())
             .border_set(border::THICK);
+
+        Clear.render(area, buf);
 
         Paragraph::new(text_lines).block(block).render(area, buf);
     }

--- a/cli/src/debugger/help.rs
+++ b/cli/src/debugger/help.rs
@@ -25,11 +25,12 @@ impl Widget for &HelpWidget {
                 "  Toggle help (this window): ".into(),
                 "h".blue().bold(),
             ]),
+            Line::from(vec!["  Toggle source list: ".into(), "l".blue().bold()]),
             Line::from(vec!["  Toggle disassembly: ".into(), "D".blue().bold()]),
             Line::from(vec!["  Toggle stack trace: ".into(), "t".blue().bold()]),
             Line::from(vec![
                 "  Toggle local stack values: ".into(),
-                "l".blue().bold(),
+                "k".blue().bold(),
             ]),
             Line::from(vec!["  Toggle output widget: ".into(), "o".blue().bold()]),
             Line::from(vec!["  run current code: ".into(), "r".blue().bold()]),

--- a/cli/src/debugger/output.rs
+++ b/cli/src/debugger/output.rs
@@ -50,7 +50,7 @@ impl Widget for &OutputWidget {
         let block = Block::bordered()
             .title(title.alignment(Alignment::Center))
             .border_style(Style::new().magenta())
-            .border_set(border::THICK);
+            .border_set(border::PLAIN);
 
         let mut lines = vec![];
         if self.scroll < text_lines.len() {

--- a/cli/src/debugger/source_list.rs
+++ b/cli/src/debugger/source_list.rs
@@ -61,8 +61,10 @@ impl SourceListWidget {
     ) -> Result<(), Box<dyn std::error::Error>> {
         if let Some(debug) = debug {
             let ip32 = ip as u32;
-            let line_info = debug.iter().find(|li| li.instruction == ip32);
-            if let Some(line_info) = line_info {
+            let line_info = debug
+                .binary_search_by_key(&ip32, |li| li.instruction)
+                .map_or_else(|res| res, |res| res);
+            if let Some(line_info) = debug.get(line_info) {
                 self.line = Some(*line_info);
                 let line = line_info.src_line as usize;
                 // When the instruction pointer moves by stepping the program, we want to follow its position.

--- a/cli/src/debugger/source_list.rs
+++ b/cli/src/debugger/source_list.rs
@@ -1,5 +1,3 @@
-use std::cmp::Ordering;
-
 use mascal::{Bytecode, LineInfo};
 use ratatui::{
     buffer::Buffer,

--- a/cli/src/debugger/source_list.rs
+++ b/cli/src/debugger/source_list.rs
@@ -48,16 +48,8 @@ impl SourceListWidget {
         if let Some(debug) = debug {
             let ip32 = ip as u32;
             let line_info = debug
-                .binary_search_by(|li| {
-                    if ip32 < li.byte_start {
-                        Ordering::Less
-                    } else if li.byte_end < ip32 {
-                        Ordering::Greater
-                    } else {
-                        Ordering::Equal
-                    }
-                })
-                .map_or_else(|l| debug.get(l), |l| debug.get(l));
+                .iter()
+                .find(|li| li.byte_start <= ip32 && ip32 <= li.byte_end);
             if let Some(line_info) = line_info {
                 let line = line_info.src_start as usize;
                 self.line = Some(line);

--- a/cli/src/debugger/source_list.rs
+++ b/cli/src/debugger/source_list.rs
@@ -1,0 +1,86 @@
+use mascal::{Bytecode, LineInfo};
+use ratatui::{
+    buffer::Buffer,
+    layout::{Alignment, Rect},
+    style::{Style, Stylize},
+    symbols::border,
+    text::{Line, Text},
+    widgets::{block::Title, Block, Paragraph, Widget},
+};
+
+pub(super) struct SourceListWidget {
+    pub(super) visible: bool,
+    pub(super) text: Vec<String>,
+    line: Option<usize>,
+    pub(super) scroll: usize,
+}
+
+impl SourceListWidget {
+    pub(super) fn new(bytecode: &Bytecode) -> (Self, Option<Box<dyn std::error::Error>>) {
+        let mut temp = String::new();
+        let mut error = None;
+        if let Some(source_file) = bytecode.debug_info().map(|d| d.file_name()) {
+            match std::fs::read_to_string(source_file) {
+                Ok(source) => temp = source,
+                Err(e) => error = Some(e.into()),
+            }
+        }
+        (
+            Self {
+                visible: true,
+                text: temp.split("\n").map(|s| s.trim().to_string()).collect(),
+                line: None,
+                scroll: 0,
+            },
+            error,
+        )
+    }
+
+    pub(super) fn update(
+        &mut self,
+        ip: usize,
+        debug: Option<&[LineInfo]>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        if let Some(debug) = debug {
+            let ip32 = ip as u32;
+            let line = debug
+                .binary_search_by_key(&ip32, |li| li.byte_start)
+                .map_or_else(|l| l, |l| l);
+            let line = line.clamp(0, self.text.len());
+            self.line = Some(line);
+            self.scroll = ip.saturating_sub(3); // Leave 3 lines before
+        }
+        Ok(())
+    }
+}
+
+impl Widget for &SourceListWidget {
+    fn render(self, area: Rect, buf: &mut Buffer)
+    where
+        Self: Sized,
+    {
+        let title =
+            Title::from(format!(" Source listing {}/{} ", self.scroll, self.text.len()).bold());
+        let block = Block::bordered()
+            .title(title.alignment(Alignment::Center))
+            .border_style(Style::new().white())
+            .border_set(border::THICK);
+
+        let mut lines = vec![];
+        if self.scroll < self.text.len() {
+            lines.extend(self.text[self.scroll..].iter().enumerate().map(|(i, v)| {
+                let current = if Some(i + self.scroll) == self.line {
+                    "*"
+                } else {
+                    " "
+                };
+                let line_num = i + self.scroll + 1;
+                Line::from(format!("{current}  {line_num:4}  {v}"))
+            }));
+        }
+
+        Paragraph::new(Text::from(lines))
+            .block(block)
+            .render(area, buf);
+    }
+}

--- a/cli/src/debugger/source_list.rs
+++ b/cli/src/debugger/source_list.rs
@@ -1,3 +1,5 @@
+mod parser;
+
 use mascal::{Bytecode, LineInfo};
 use ratatui::{
     buffer::Buffer,
@@ -7,6 +9,8 @@ use ratatui::{
     text::{Line, Text},
     widgets::{block::Title, Block, Paragraph, Widget},
 };
+
+use self::parser::style_text;
 
 pub(super) struct SourceListWidget {
     pub(super) visible: bool,
@@ -73,13 +77,9 @@ impl Widget for &SourceListWidget {
         let mut lines = vec![];
         if self.scroll < self.text.len() {
             lines.extend(self.text[self.scroll..].iter().enumerate().map(|(i, v)| {
-                let current = if Some(i + self.scroll + 1) == self.line {
-                    "*"
-                } else {
-                    " "
-                };
                 let line_num = i + self.scroll + 1;
-                Line::from(format!("{current}  {line_num:4}  {v}"))
+                let v = style_text(Some(i + self.scroll + 1) == self.line, line_num, v);
+                Line::from(v)
             }));
         }
 

--- a/cli/src/debugger/source_list/parser.rs
+++ b/cli/src/debugger/source_list/parser.rs
@@ -1,0 +1,107 @@
+use nom::{
+    branch::alt,
+    bytes::complete::{tag, take_until},
+    character::complete::{alpha1, alphanumeric1, char, one_of},
+    combinator::{opt, recognize},
+    multi::{many0, many1},
+    sequence::{delimited, pair, terminated},
+    Finish, IResult,
+};
+use ratatui::{style::Stylize, text::Span};
+
+pub(super) fn style_text(is_current: bool, line_num: usize, s: &str) -> Vec<Span> {
+    let current = if is_current { "*" } else { " " };
+    let mut line = vec![Span::from(format!("{current}  {line_num:4} "))];
+    if let Ok((_, s)) = text(s) {
+        line.extend_from_slice(&s);
+    }
+    line
+}
+
+fn identifier(input: &str) -> IResult<&str, &str> {
+    recognize(pair(
+        alt((alpha1, tag("_"))),
+        many0(alt((alphanumeric1, tag("_")))),
+    ))(input)
+}
+
+fn keyword(input: &str) -> IResult<&str, Span> {
+    let (r, id) = identifier(input)?;
+    Ok(
+        if matches!(
+            id,
+            "fn" | "if" | "else" | "for" | "in" | "var" | "while" | "loop" | "break"
+        ) {
+            (r, id.blue())
+        } else {
+            (r, id.light_cyan())
+        },
+    )
+}
+
+fn decimal(input: &str) -> IResult<&str, &str> {
+    recognize(many1(terminated(one_of("0123456789"), many0(char('_')))))(input)
+}
+
+fn decimal_value(i: &str) -> IResult<&str, Span> {
+    recognize(pair(opt(one_of("+-")), decimal))(i).map(|(r, s)| (r, s.light_green()))
+}
+
+fn comment(r: &str) -> IResult<&str, Span> {
+    recognize(delimited(tag("/*"), take_until("*/"), tag("*/")))(r).map(|(r, s)| (r, s.green()))
+}
+
+fn non_ident(mut input: &str) -> IResult<&str, Span> {
+    let start = input;
+    let mut last = None;
+    loop {
+        let mut iter = input.chars();
+        let Some(next) = iter.next() else { break };
+        if next.is_alphanumeric() || next == '_' {
+            break;
+        }
+        if next == '*' && last == Some('/') {
+            break;
+        }
+        last = Some(next);
+        input = iter.as_str();
+    }
+    if start == input {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            "",
+            nom::error::ErrorKind::Alpha,
+        )));
+    }
+    Ok((
+        input,
+        start[..input.as_ptr() as usize - start.as_ptr() as usize].into(),
+    ))
+}
+
+fn text(input: &str) -> Result<(&str, Vec<Span>), nom::error::Error<&str>> {
+    many0(alt((comment, keyword, decimal_value, non_ident)))(input).finish()
+}
+
+#[test]
+fn test_non_ident() {
+    let s = "!!! hello";
+    assert_eq!(non_ident(s), Ok(("hello", "!!! ".into())));
+}
+
+#[test]
+fn test_text() {
+    let s = "fn hello 1";
+    assert_eq!(
+        text(s),
+        Ok((
+            "",
+            vec![
+                "fn".blue(),
+                " ".into(),
+                "hello".light_cyan(),
+                " ".into(),
+                "1".light_green()
+            ]
+        ))
+    );
+}

--- a/cli/src/debugger/stack.rs
+++ b/cli/src/debugger/stack.rs
@@ -44,7 +44,7 @@ impl Widget for &StackWidget {
         let block = Block::bordered()
             .title(title.alignment(Alignment::Center))
             .border_style(Style::new().cyan())
-            .border_set(border::THICK);
+            .border_set(border::PLAIN);
 
         let mut lines = vec![];
         if self.scroll < text_lines.len() {

--- a/cli/src/debugger/stack_trace.rs
+++ b/cli/src/debugger/stack_trace.rs
@@ -50,7 +50,7 @@ impl Widget for &StackTraceWidget {
         let block = Block::bordered()
             .title(title.alignment(Alignment::Center))
             .border_style(Style::new().blue())
-            .border_set(border::THICK);
+            .border_set(border::PLAIN);
 
         let mut lines = vec![];
         if self.scroll < text_lines.len() {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -117,7 +117,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
             let out = Rc::new(RefCell::new(std::io::stdout()));
             bytecode.add_std_fn(out);
-            interpret(&bytecode).map_err(|e| e.to_string())?;
+            if args.debugger {
+                run_debugger(bytecode)?;
+            } else {
+                interpret(&bytecode).map_err(|e| e.to_string())?;
+            }
         } else {
             let mut contents = String::new();
             file.read_to_string(&mut contents)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -7,7 +7,6 @@ use mascal::*;
 use ::colored::Colorize;
 use std::{
     cell::RefCell,
-    collections::HashMap,
     fs::File,
     io::{prelude::*, BufReader, BufWriter},
     rc::Rc,
@@ -42,6 +41,8 @@ struct Args {
     signatures: bool,
     #[clap(short = 'D', long, help = "Enable interactive debugger")]
     debugger: bool,
+    #[clap(short = 'g', long, help = "Enable debug information in the bytecode")]
+    debug_info: bool,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -67,7 +68,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let source_file = source_file.unwrap_or("<Unknown>");
 
         if args.compile || args.compile_and_run {
-            let mut bytecode = compile(&result.1, HashMap::new())
+            let mut bytecode = CompilerBuilder::new(&result.1)
+                .enable_debug(args.debug_info)
+                .compile(&mut std::io::sink())
                 .map_err(|e| format!("Error: {}:{}", source_file, e))?;
             bytecode.set_file_name(source_file);
             if args.signatures {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -64,9 +64,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
 
+        let source_file = source_file.unwrap_or("<Unknown>");
+
         if args.compile || args.compile_and_run {
             let mut bytecode = compile(&result.1, HashMap::new())
-                .map_err(|e| format!("Error: {}:{}", source_file.unwrap_or("<Unknown>"), e))?;
+                .map_err(|e| format!("Error: {}:{}", source_file, e))?;
+            bytecode.set_file_name(source_file);
             if args.signatures {
                 bytecode
                     .signatures(&mut std::io::stdout())

--- a/parser/src/bytecode.rs
+++ b/parser/src/bytecode.rs
@@ -158,16 +158,25 @@ impl std::fmt::Display for Instruction {
     }
 }
 
+fn write_usize(val: usize, writer: &mut impl Write) -> std::io::Result<()> {
+    writer.write_all(&(val as u32).to_le_bytes())?;
+    Ok(())
+}
+
+fn read_usize(reader: &mut impl Read) -> std::io::Result<usize> {
+    let mut buf = [0u8; std::mem::size_of::<u32>()];
+    reader.read_exact(&mut buf)?;
+    Ok(u32::from_le_bytes(buf) as usize)
+}
+
 fn write_str(s: &str, writer: &mut impl Write) -> std::io::Result<()> {
-    writer.write_all(&s.len().to_le_bytes())?;
+    write_usize(s.len(), writer)?;
     writer.write_all(&s.as_bytes())?;
     Ok(())
 }
 
 fn read_str(reader: &mut impl Read) -> Result<String, ReadError> {
-    let mut len = [0u8; std::mem::size_of::<usize>()];
-    reader.read_exact(&mut len)?;
-    let len = usize::from_le_bytes(len);
+    let len = read_usize(reader)?;
     let mut buf = vec![0u8; len];
     reader.read_exact(&mut buf)?;
     Ok(String::from_utf8(buf)?)

--- a/parser/src/bytecode.rs
+++ b/parser/src/bytecode.rs
@@ -295,13 +295,10 @@ impl Bytecode {
                 _ => return Err(ReadError::UnknownTag(tag)),
             }
         }
-        let loaded_fn = functions
+        functions
             .iter()
             .find(|(name, _)| *name == "")
             .ok_or(ReadError::NoMainFound)?;
-        if let FnProto::Code(ref _code) = loaded_fn.1 {
-            dbg_println!("instructions: {:#?}", _code.instructions);
-        }
         Ok(Bytecode { functions, debug })
     }
 

--- a/parser/src/bytecode.rs
+++ b/parser/src/bytecode.rs
@@ -268,14 +268,7 @@ impl Bytecode {
         }
 
         writer.write_all(&DEBUG_TAG)?;
-        writer.write_all(&self.debug.len().to_le_bytes())?;
-        for (fname, debug) in self.debug.iter() {
-            write_str(fname, writer)?;
-            writer.write_all(&debug.len().to_le_bytes())?;
-            for line_info in debug {
-                line_info.serialize(writer)?;
-            }
-        }
+        Self::write_debug_info(&self.debug, writer)?;
         Ok(())
     }
 
@@ -290,7 +283,7 @@ impl Bytecode {
             };
             match tag {
                 FUNCTION_TAG => functions = Self::read_functions(reader)?,
-                DEBUG_TAG => debug = Self::read_debug(reader)?,
+                DEBUG_TAG => debug = Self::read_debug_info(reader)?,
                 _ => return Err(ReadError::UnknownTag(tag)),
             }
         }

--- a/parser/src/bytecode/debug_info.rs
+++ b/parser/src/bytecode/debug_info.rs
@@ -5,10 +5,25 @@ use std::{
 
 use crate::ReadError;
 
-use super::{read_str, Bytecode};
+use super::{read_str, write_str, Bytecode};
 
 impl Bytecode {
-    pub(super) fn read_debug(
+    pub(super) fn write_debug_info(
+        debug: &DebugInfo,
+        writer: &mut impl Write,
+    ) -> std::io::Result<()> {
+        writer.write_all(&debug.len().to_le_bytes())?;
+        for (fname, debug) in debug.iter() {
+            write_str(fname, writer)?;
+            writer.write_all(&debug.len().to_le_bytes())?;
+            for line_info in debug {
+                line_info.serialize(writer)?;
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) fn read_debug_info(
         reader: &mut impl Read,
     ) -> Result<HashMap<String, Vec<LineInfo>>, ReadError> {
         println!("Reading DEBUG tag");

--- a/parser/src/bytecode/debug_info.rs
+++ b/parser/src/bytecode/debug_info.rs
@@ -26,11 +26,9 @@ impl Bytecode {
 
     pub(super) fn read_debug_info(reader: &mut impl Read) -> Result<DebugInfo, ReadError> {
         let file_name = read_str(reader)?;
-        println!("Reading DEBUG tag");
         let mut len = [0u8; std::mem::size_of::<usize>()];
         reader.read_exact(&mut len)?;
         let len = usize::from_le_bytes(len);
-        println!("Reading {len} debug info");
         let source_map = (0..len)
             .map(|_| -> Result<_, ReadError> {
                 let name = read_str(reader)?;
@@ -43,7 +41,6 @@ impl Bytecode {
                 Ok((name, line_info))
             })
             .collect::<Result<HashMap<String, Vec<LineInfo>>, _>>()?;
-        println!("Debug: {source_map:?}");
         Ok(DebugInfo {
             file_name,
             source_map,
@@ -66,6 +63,10 @@ impl DebugInfo {
 
     pub fn get(&self, fname: &str) -> Option<&Vec<LineInfo>> {
         self.source_map.get(fname)
+    }
+
+    pub fn file_name(&self) -> &str {
+        &self.file_name
     }
 
     pub(super) fn set_file_name(&mut self, file_name: impl Into<String>) {

--- a/parser/src/bytecode/debug_info.rs
+++ b/parser/src/bytecode/debug_info.rs
@@ -1,0 +1,74 @@
+use std::{
+    collections::HashMap,
+    io::{Read, Write},
+};
+
+use crate::ReadError;
+
+use super::{read_str, Bytecode};
+
+impl Bytecode {
+    pub(super) fn read_debug(
+        reader: &mut impl Read,
+    ) -> Result<HashMap<String, Vec<LineInfo>>, ReadError> {
+        println!("Reading DEBUG tag");
+        let mut len = [0u8; std::mem::size_of::<usize>()];
+        reader.read_exact(&mut len)?;
+        let len = usize::from_le_bytes(len);
+        println!("Reading {len} debug info");
+        let debug = (0..len)
+            .map(|_| -> Result<_, ReadError> {
+                let name = read_str(reader)?;
+                let mut buf = [0u8; std::mem::size_of::<usize>()];
+                reader.read_exact(&mut buf)?;
+                let len = usize::from_le_bytes(buf);
+                let line_info = (0..len)
+                    .map(|_| LineInfo::deserialize(reader))
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok((name, line_info))
+            })
+            .collect::<Result<HashMap<String, Vec<LineInfo>>, _>>()?;
+        println!("Debug: {debug:?}");
+        Ok(debug)
+    }
+}
+
+pub type DebugInfo = HashMap<String, Vec<LineInfo>>;
+
+#[derive(Debug)]
+/// Source mapping between line number and bytecode bytes.
+/// u32 should suffice since no one would write more than 4 billion bytes of source codes.
+pub struct LineInfo {
+    pub src_start: u32,
+    pub src_end: u32,
+    pub byte_start: u32,
+    pub byte_end: u32,
+}
+
+impl LineInfo {
+    pub(crate) fn serialize(&self, writer: &mut impl Write) -> std::io::Result<()> {
+        writer.write_all(&self.src_start.to_le_bytes())?;
+        writer.write_all(&self.src_end.to_le_bytes())?;
+        writer.write_all(&self.byte_start.to_le_bytes())?;
+        writer.write_all(&self.byte_end.to_le_bytes())?;
+        Ok(())
+    }
+
+    pub(crate) fn deserialize(reader: &mut impl Read) -> std::io::Result<Self> {
+        let mut buf = [0u8; std::mem::size_of::<u32>()];
+        reader.read_exact(&mut buf)?;
+        let src_start = u32::from_le_bytes(buf);
+        reader.read_exact(&mut buf)?;
+        let src_end = u32::from_le_bytes(buf);
+        reader.read_exact(&mut buf)?;
+        let byte_start = u32::from_le_bytes(buf);
+        reader.read_exact(&mut buf)?;
+        let byte_end = u32::from_le_bytes(buf);
+        Ok(Self {
+            src_start,
+            src_end,
+            byte_start,
+            byte_end,
+        })
+    }
+}

--- a/parser/src/bytecode/debug_info.rs
+++ b/parser/src/bytecode/debug_info.rs
@@ -75,7 +75,7 @@ impl DebugInfo {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 /// Source mapping between line number and bytecode bytes.
 /// u32 should suffice since no one would write more than 4 billion bytes of source codes.
 pub struct LineInfo {

--- a/parser/src/bytecode/debug_info.rs
+++ b/parser/src/bytecode/debug_info.rs
@@ -48,6 +48,7 @@ impl Bytecode {
     }
 }
 
+#[derive(Debug)]
 pub struct DebugInfo {
     file_name: String,
     source_map: HashMap<String, Vec<LineInfo>>,

--- a/parser/src/bytecode/debug_info.rs
+++ b/parser/src/bytecode/debug_info.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::ReadError;
 
-use super::{read_str, write_str, Bytecode};
+use super::{read_str, read_usize, write_str, write_usize, Bytecode};
 
 impl Bytecode {
     pub(super) fn write_debug_info(
@@ -13,7 +13,7 @@ impl Bytecode {
         writer: &mut impl Write,
     ) -> std::io::Result<()> {
         write_str(&debug.file_name, writer)?;
-        writer.write_all(&debug.source_map.len().to_le_bytes())?;
+        write_usize(debug.source_map.len(), writer)?;
         for (fname, debug) in debug.source_map.iter() {
             write_str(fname, writer)?;
             writer.write_all(&debug.len().to_le_bytes())?;
@@ -26,9 +26,7 @@ impl Bytecode {
 
     pub(super) fn read_debug_info(reader: &mut impl Read) -> Result<DebugInfo, ReadError> {
         let file_name = read_str(reader)?;
-        let mut len = [0u8; std::mem::size_of::<usize>()];
-        reader.read_exact(&mut len)?;
-        let len = usize::from_le_bytes(len);
+        let len = read_usize(reader)?;
         let source_map = (0..len)
             .map(|_| -> Result<_, ReadError> {
                 let name = read_str(reader)?;

--- a/parser/src/bytecode/debug_info.rs
+++ b/parser/src/bytecode/debug_info.rs
@@ -77,36 +77,36 @@ impl DebugInfo {
 /// Source mapping between line number and bytecode bytes.
 /// u32 should suffice since no one would write more than 4 billion bytes of source codes.
 pub struct LineInfo {
-    pub src_start: u32,
-    pub src_end: u32,
-    pub byte_start: u32,
-    pub byte_end: u32,
+    pub instruction: u32,
+    pub src_line: u32,
+    pub src_column: u32,
+    pub src_len: u32,
 }
 
 impl LineInfo {
     pub(crate) fn serialize(&self, writer: &mut impl Write) -> std::io::Result<()> {
-        writer.write_all(&self.src_start.to_le_bytes())?;
-        writer.write_all(&self.src_end.to_le_bytes())?;
-        writer.write_all(&self.byte_start.to_le_bytes())?;
-        writer.write_all(&self.byte_end.to_le_bytes())?;
+        writer.write_all(&self.instruction.to_le_bytes())?;
+        writer.write_all(&self.src_line.to_le_bytes())?;
+        writer.write_all(&self.src_column.to_le_bytes())?;
+        writer.write_all(&self.src_len.to_le_bytes())?;
         Ok(())
     }
 
     pub(crate) fn deserialize(reader: &mut impl Read) -> std::io::Result<Self> {
         let mut buf = [0u8; std::mem::size_of::<u32>()];
         reader.read_exact(&mut buf)?;
-        let src_start = u32::from_le_bytes(buf);
+        let instruction = u32::from_le_bytes(buf);
         reader.read_exact(&mut buf)?;
-        let src_end = u32::from_le_bytes(buf);
+        let src_line = u32::from_le_bytes(buf);
         reader.read_exact(&mut buf)?;
-        let byte_start = u32::from_le_bytes(buf);
+        let src_column = u32::from_le_bytes(buf);
         reader.read_exact(&mut buf)?;
-        let byte_end = u32::from_le_bytes(buf);
+        let src_len = u32::from_le_bytes(buf);
         Ok(Self {
-            src_start,
-            src_end,
-            byte_start,
-            byte_end,
+            instruction,
+            src_line,
+            src_column,
+            src_len,
         })
     }
 }

--- a/parser/src/compiler.rs
+++ b/parser/src/compiler.rs
@@ -16,7 +16,7 @@ use crate::{
     interpreter::{eval, EvalContext, RunResult},
     parser::{ExprEnum, Expression, Statement},
     value::{ArrayInt, TupleEntry},
-    Span, TypeDecl, Value,
+    DebugInfo, Span, TypeDecl, Value,
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -231,7 +231,7 @@ fn compile_int<'src, 'ast>(
 
     Ok(Bytecode {
         functions,
-        debug: env.debug,
+        debug: Some(DebugInfo::new(env.debug)),
     })
 }
 

--- a/parser/src/compiler.rs
+++ b/parser/src/compiler.rs
@@ -166,11 +166,6 @@ impl<'a> Compiler<'a> {
     fn source_map(&self) -> Vec<LineInfo> {
         let mut source_map = vec![];
         let mut last_range: Option<LineInfo> = None;
-        println!(
-            "source_map: {} {:?}",
-            self.bytecode.instructions.len(),
-            self.line_info
-        );
         for i in 0..self.bytecode.instructions.len() {
             let Some(&src_line) = self.line_info.get(&(i as u32)) else {
                 continue;

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -15,7 +15,7 @@ mod type_tags;
 mod value;
 mod vm;
 
-pub use self::bytecode::{Bytecode, FnBytecode, Instruction, OpCode};
+pub use self::bytecode::{Bytecode, DebugInfo, FnBytecode, Instruction, LineInfo, OpCode};
 pub use self::compiler::*;
 pub use self::interpreter::{coerce_type, run, EvalContext, EvalError, FuncDef};
 pub use self::parser::{span_source as source, ArgDecl, ReadError, Span};

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -26,6 +26,7 @@ pub enum ReadError {
     FromUtf8(FromUtf8Error),
     NoMainFound,
     UndefinedOpCode(u8),
+    UnknownTag([u8; 2]),
 }
 
 impl From<std::io::Error> for ReadError {
@@ -47,6 +48,7 @@ impl std::fmt::Display for ReadError {
             ReadError::FromUtf8(e) => write!(f, "{e}"),
             ReadError::NoMainFound => write!(f, "No main function found"),
             ReadError::UndefinedOpCode(code) => write!(f, "Opcode \"{code:02X}\" unrecognized!"),
+            ReadError::UnknownTag(code) => write!(f, "Unknwon tag \"{code:?}\" encountered"),
         }
     }
 }

--- a/parser/src/vm.rs
+++ b/parser/src/vm.rs
@@ -169,7 +169,8 @@ impl<'a> Vm<'a> {
             // Empty call stack is not an error
             return Ok(());
         };
-        for (i, value) in self.stack[ci.stack_base..ci.stack_size].iter().enumerate() {
+        let top = (ci.stack_base + ci.stack_size).min(self.stack.len());
+        for (i, value) in self.stack[ci.stack_base..top].iter().enumerate() {
             writeln!(f, "  [{i}] {value}")?;
         }
         Ok(())

--- a/parser/src/vm.rs
+++ b/parser/src/vm.rs
@@ -40,7 +40,7 @@ impl<'a> CallInfo<'a> {
         self.fun
     }
 
-    pub fn instuction_ptr(&self) -> usize {
+    pub fn instruction_ptr(&self) -> usize {
         self.ip
     }
 


### PR DESCRIPTION
We implemented TUI debugger in #23, which is great, but there is one problem. We could not see the source code in the bytecode debugger, which is a huge barrier to those who are not familiar with the bytecode, which is almost everyone, because this is a bytecode I invented.

So we introduce the source listing, as you can see in the top right in the screenshot below.

![image](https://github.com/user-attachments/assets/0b0719f0-ea9b-4fee-89b6-607e5bc8ac2e)

Of course the debugger will follow currently executing line by source mapping from bytecode instructions to the source code.

https://github.com/user-attachments/assets/e70a9526-aaa4-47de-b482-824192e308ee

However, it requires changes to the bytecode format, because we need to embed this information of mapping.

Inspired by gcc, the CLI has `-g` option now, to enable debugging information. It tend to make the bytecode 2x or larger, so you would not want to enable debug information all the time.

# TODOs

* [x] Improve search by sorting by instruction order, since the execution is run on the instructions, not in the order of source code. Right now we are searching the source map linearly to find the corresponding source line number, which is awfully inefficient.
* [x] Sub-line mapping: right now the source map is based on source line number, but it is sometimes not fine enough, because a single line of source code can emit many instructions.
* [x] Implement breakpoints. It's not necessarily in this PR.
