### PR TITLE
Support structs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "rust-analyzer.linkedProjects": [
         "parser/Cargo.toml",
+        "wasm/Cargo.toml",
         "vscode-ext/mascal-lsp-server/Cargo.toml"
     ]
 }

--- a/parser/src/bytecode.rs
+++ b/parser/src/bytecode.rs
@@ -79,6 +79,8 @@ pub enum OpCode {
     /// Casts a value at arg0 to a type indicated by arg1. I'm feeling this should be a standard library function
     /// rather than a opcode, but let's finish implementation compatible with AST interpreter first.
     Cast,
+    /// Make a tuple with arg0 argument on the stack at index arg1.
+    MakeTuple,
 }
 
 macro_rules! impl_op_from {
@@ -137,7 +139,8 @@ impl_op_from!(
     Jf,
     Call,
     Ret,
-    Cast
+    Cast,
+    MakeTuple
 );
 
 /// A single instruction in a bytecode. OpCodes can have 0 to 2 arguments.

--- a/parser/src/bytecode.rs
+++ b/parser/src/bytecode.rs
@@ -50,8 +50,8 @@ pub enum OpCode {
     BitNot,
     /// Unary negation (-).
     Neg,
-    /// Get an element of an array (or a table in the future) at arg0 with the key at arg1, and make a copy at arg1.
-    /// Array elements are always Rc wrapped, so the user can assign into it.
+    /// Get an element of an array or a struct (or a table in the future) at arg0 with the key at arg1, and make a
+    /// copy at arg1.
     Get,
     Set,
     /// Set a value to the special register to use in later instructions.

--- a/parser/src/bytecode.rs
+++ b/parser/src/bytecode.rs
@@ -78,8 +78,12 @@ pub enum OpCode {
     /// Casts a value at arg0 to a type indicated by arg1. I'm feeling this should be a standard library function
     /// rather than a opcode, but let's finish implementation compatible with AST interpreter first.
     Cast,
-    /// Make a tuple with arg0 argument on the stack at index arg1.
+    /// Make a tuple with arg0 arguments on the stack at index arg1. arg1 + 1 to arg1 + arg0 are the indices of the
+    /// values to read from.
     MakeTuple,
+    /// Make a tuple with arg0 arguments on the stack at index arg1. arg1 + 1 to arg1 + arg0 are the indices of the
+    /// values to read from. arg1 shall contain the type name (struct name) before invocation.
+    MakeStruct,
 }
 
 macro_rules! impl_op_from {
@@ -139,7 +143,8 @@ impl_op_from!(
     Call,
     Ret,
     Cast,
-    MakeTuple
+    MakeTuple,
+    MakeStruct
 );
 
 /// A single instruction in a bytecode. OpCodes can have 0 to 2 arguments.

--- a/parser/src/bytecode.rs
+++ b/parser/src/bytecode.rs
@@ -13,9 +13,8 @@ use std::{
 pub use self::debug_info::{DebugInfo, FunctionInfo, LineInfo};
 
 use crate::{
-    interpreter::{
-        s_hex_string, s_len, s_print, s_push, s_puts, s_resize, s_strlen, s_type, EvalError,
-    },
+    eval_error::EvalError,
+    interpreter::{s_hex_string, s_len, s_print, s_push, s_puts, s_resize, s_strlen, s_type},
     parser::ReadError,
     value::Value,
 };

--- a/parser/src/coercion.rs
+++ b/parser/src/coercion.rs
@@ -177,5 +177,11 @@ pub fn coerce_type(value: &Value, target: &TypeDecl) -> Result<Value, EvalError>
                 ));
             }
         }
+        TypeDecl::TypeName(name) => {
+            return Err(EvalError::CoerceError(
+                value.to_string(),
+                format!("typename {name}"),
+            ));
+        }
     })
 }

--- a/parser/src/coercion.rs
+++ b/parser/src/coercion.rs
@@ -93,9 +93,7 @@ fn _coerce_var(value: &Value, target: &Value, typedefs: &TypeMap) -> Result<Valu
                             .borrow()
                             .values
                             .iter()
-                            .map(|val| -> EvalResult<_> {
-                                Ok(coerce_type(val, inner_type, typedefs)?)
-                            })
+                            .map(|val| -> EvalResult<_> { Ok(coerce_type(val, inner_type)?) })
                             .collect::<Result<_, _>>()?,
                     ))
                 } else {
@@ -128,7 +126,7 @@ fn _coerce_var(value: &Value, target: &Value, typedefs: &TypeMap) -> Result<Valu
                             .map(|(val, tgt)| -> EvalResult<_> {
                                 Ok(TupleEntry {
                                     decl: tgt.decl.clone(),
-                                    value: coerce_type(&val.value, &tgt.decl, typedefs)?,
+                                    value: coerce_type(&val.value, &tgt.decl)?,
                                 })
                             })
                             .collect::<Result<_, _>>()?,
@@ -143,7 +141,7 @@ fn _coerce_var(value: &Value, target: &Value, typedefs: &TypeMap) -> Result<Valu
         }
         Value::Struct(str) => {
             let borrow = str.borrow();
-            let ty = typedefs
+            let _ty = typedefs
                 .get(&borrow.name)
                 .ok_or_else(|| EvalError::CoerceError(borrow.name.clone(), "".to_string()))?;
             let Value::Struct(value) = value else {
@@ -154,11 +152,7 @@ fn _coerce_var(value: &Value, target: &Value, typedefs: &TypeMap) -> Result<Valu
     })
 }
 
-pub fn coerce_type(
-    value: &Value,
-    target: &TypeDecl,
-    typedefs: &TypeMap,
-) -> Result<Value, EvalError> {
+pub fn coerce_type(value: &Value, target: &TypeDecl) -> Result<Value, EvalError> {
     Ok(match target {
         TypeDecl::Any => value.clone(),
         TypeDecl::F64 => Value::F64(coerce_f64(value)?),

--- a/parser/src/compiler.rs
+++ b/parser/src/compiler.rs
@@ -777,6 +777,16 @@ fn emit_expr<'src>(expr: &Expression<'src>, compiler: &mut Compiler) -> CompileR
             compiler.locals.pop();
             Ok(res)
         }
+        ExprEnum::StructLiteral(_name, fields) => {
+            for (_name, ex) in fields {
+                let stk_from = emit_expr(ex, compiler)?;
+                compiler.locals.last_mut().unwrap().push(LocalVar {
+                    name: "".to_string(),
+                    stack_idx: stk_from,
+                });
+            }
+            todo!()
+        }
     };
     compiler.end_src_pos(expr.span.into());
     res

--- a/parser/src/compiler.rs
+++ b/parser/src/compiler.rs
@@ -512,7 +512,8 @@ fn emit_stmts<'src>(
                 compiler.push_inst(OpCode::Jmp, 0, 0);
                 compiler.break_ips.push(break_ip);
             }
-            Statement::Comment(_) => (),
+            // For now, structs are concepts only at compile time.
+            Statement::Struct(_) | Statement::Comment(_) => (),
         }
     }
     Ok(last_target)

--- a/parser/src/compiler/error.rs
+++ b/parser/src/compiler/error.rs
@@ -14,6 +14,7 @@ pub enum CompileErrorKind {
     AssignToLiteral(String),
     NonLValue(String),
     TypeNameNotFound(String),
+    FieldNotFound(String),
     FromUtf8Error(std::string::FromUtf8Error),
     IoError(std::io::Error),
 }
@@ -55,6 +56,7 @@ impl std::fmt::Display for CompileErrorKind {
                 ex
             ),
             Self::TypeNameNotFound(name) => write!(f, "Struct {name} is not defined"),
+            Self::FieldNotFound(name) => write!(f, "Field {name} is not defined"),
             Self::FromUtf8Error(e) => e.fmt(f),
             Self::IoError(e) => e.fmt(f),
         }

--- a/parser/src/compiler/error.rs
+++ b/parser/src/compiler/error.rs
@@ -13,6 +13,7 @@ pub enum CompileErrorKind {
     UnknownNamedArg,
     AssignToLiteral(String),
     NonLValue(String),
+    TypeNameNotFound(String),
     FromUtf8Error(std::string::FromUtf8Error),
     IoError(std::io::Error),
 }
@@ -53,6 +54,7 @@ impl std::fmt::Display for CompileErrorKind {
                 "Attempt assignment to expression {} which is not an lvalue.",
                 ex
             ),
+            Self::TypeNameNotFound(name) => write!(f, "Struct {name} is not defined"),
             Self::FromUtf8Error(e) => e.fmt(f),
             Self::IoError(e) => e.fmt(f),
         }

--- a/parser/src/compiler/lvalue.rs
+++ b/parser/src/compiler/lvalue.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     parser::{ExprEnum, Expression},
-    OpCode,
+    OpCode, Value,
 };
 
 use super::{
@@ -80,10 +80,11 @@ pub(super) fn emit_lvalue<'src, 'env, 'c>(
                     CompileError::new(*postfix, CEK::FieldNotFound(postfix.to_string()))
                 })?;
             let prefix = emit_lvalue(prefix, compiler)?;
+            let stk_field_idx = compiler.find_or_create_literal(&Value::I64(field_idx as i64));
             match prefix {
                 LValue::Variable(name) => Ok(LValue::ArrayRef(
                     compiler.find_local(&name, ex.span)?.stack_idx,
-                    field_idx,
+                    stk_field_idx,
                 )),
                 LValue::ArrayRef(arr, subidx) => {
                     let subidx_copy = compiler.target_stack.len();
@@ -99,7 +100,7 @@ pub(super) fn emit_lvalue<'src, 'env, 'c>(
                         .bytecode
                         .push_inst(OpCode::Get, arr as u8, subidx_copy as u16);
 
-                    Ok(LValue::ArrayRef(subidx_copy, field_idx))
+                    Ok(LValue::ArrayRef(subidx_copy, stk_field_idx))
                 }
             }
         }

--- a/parser/src/compiler/lvalue.rs
+++ b/parser/src/compiler/lvalue.rs
@@ -19,7 +19,7 @@ pub(super) enum LValue {
 
 pub(super) fn emit_lvalue<'src, 'env, 'c>(
     ex: &Expression<'src>,
-    compiler: &'c mut Compiler<'env>,
+    compiler: &'c mut Compiler<'env, 'src>,
 ) -> CompileResult<'src, LValue> {
     match &ex.expr {
         ExprEnum::NumLiteral(_, _)

--- a/parser/src/compiler/lvalue.rs
+++ b/parser/src/compiler/lvalue.rs
@@ -10,10 +10,12 @@ use super::{
 };
 
 /// Internal to the compiler
+#[derive(Debug)]
 pub(super) enum LValue {
     /// A variable identified by a name
     Variable(String),
-    /// Reference to an array element of a variable in local stack, e.g. an array element.
+    /// Reference to an element of a variable in local stack, either an array element or a struct field.
+    /// Note that tuples will not use it since tuples are immutable.
     ArrayRef(usize, usize),
 }
 
@@ -58,6 +60,46 @@ pub(super) fn emit_lvalue<'src, 'env, 'c>(
                         .push_inst(OpCode::Get, arr as u8, subidx_copy as u16);
 
                     Ok(LValue::ArrayRef(subidx_copy, idx))
+                }
+            }
+        }
+        ExprEnum::FieldAccess {
+            prefix,
+            postfix,
+            def,
+        } => {
+            let st_ty = def
+                .as_ref()
+                .ok_or_else(|| CompileError::new(ex.span, CEK::TypeNameNotFound("???".into())))?;
+            let (field_idx, _) = st_ty
+                .fields
+                .iter()
+                .enumerate()
+                .find(|(_, field)| *field.name == **postfix)
+                .ok_or_else(|| {
+                    CompileError::new(*postfix, CEK::FieldNotFound(postfix.to_string()))
+                })?;
+            let prefix = emit_lvalue(prefix, compiler)?;
+            match prefix {
+                LValue::Variable(name) => Ok(LValue::ArrayRef(
+                    compiler.find_local(&name, ex.span)?.stack_idx,
+                    field_idx,
+                )),
+                LValue::ArrayRef(arr, subidx) => {
+                    let subidx_copy = compiler.target_stack.len();
+                    compiler.target_stack.push(Target::None);
+
+                    // First, copy the index to be overwritten by Get instruction
+                    compiler
+                        .bytecode
+                        .push_inst(OpCode::Move, subidx as u8, subidx_copy as u16);
+
+                    // Second, get the element from the array reference
+                    compiler
+                        .bytecode
+                        .push_inst(OpCode::Get, arr as u8, subidx_copy as u16);
+
+                    Ok(LValue::ArrayRef(subidx_copy, field_idx))
                 }
             }
         }

--- a/parser/src/eval_error.rs
+++ b/parser/src/eval_error.rs
@@ -1,0 +1,143 @@
+use crate::{value::ValueError, TypeDecl};
+
+/// Error type for the AST intepreter and bytecode interpreter.
+/// Note that it is shared among 2 kinds of interpreters, so some of them only happen in either kind.
+/// Also note that it is supposed to be displayed with Display or "{}" format, not with Debug or "{:?}".
+///
+/// It owns the value so it is not bounded by a lifetime.
+/// The information about the error shold be converted to a string (by `format!("{:?}")`) before wrapping it
+/// into `EvalError`.
+#[non_exhaustive]
+#[derive(Debug)]
+pub enum EvalError {
+    Other(String),
+    CoerceError(String, String),
+    OpError(String, String),
+    CmpError(String, String),
+    FloatOpError(String, String),
+    StrOpError(String, String),
+    DisallowedBreak,
+    VarNotFound(String),
+    FnNotFound(String),
+    ArrayOutOfBounds(usize, usize),
+    TupleOutOfBounds(usize, usize),
+    IndexNonArray,
+    NeedRef(String),
+    NoMatchingArg(String, String),
+    MissingArg(String),
+    BreakInToplevel,
+    BreakInFnArg,
+    NonIntegerIndex,
+    NonIntegerBitwise(String),
+    NoMainFound,
+    NonNameFnRef(String),
+    CallStackUndeflow,
+    IncompatibleArrayLength(usize, usize),
+    AssignToLiteral(String),
+    IndexNonNum,
+    NonLValue(String),
+    PrematureEnd,
+    WrongArgType(String, String),
+    IOError(std::io::Error),
+    ValueError(ValueError),
+    NoStructFound(String),
+    NoFieldFound(String),
+    TypeCheck(String),
+    ExpectStruct(TypeDecl),
+}
+
+impl std::convert::From<ValueError> for EvalError {
+    fn from(value: ValueError) -> Self {
+        Self::ValueError(value)
+    }
+}
+
+impl std::error::Error for EvalError {}
+
+impl std::fmt::Display for EvalError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Other(e) => write!(f, "Unknown error: {e}"),
+            Self::CoerceError(from, to) => {
+                write!(f, "Coercing from {from:?} to {to:?} is disallowed")
+            }
+            Self::OpError(lhs, rhs) => {
+                write!(f, "Unsupported operation between {lhs:?} and {rhs:?}")
+            }
+            Self::CmpError(lhs, rhs) => {
+                write!(f, "Unsupported comparison between {lhs:?} and {rhs:?}",)
+            }
+            Self::FloatOpError(lhs, rhs) => {
+                write!(f, "Unsupported float operation between {lhs:?} and {rhs:?}")
+            }
+            Self::StrOpError(lhs, rhs) => write!(
+                f,
+                "Unsupported string operation between {lhs:?} and {rhs:?}"
+            ),
+            Self::DisallowedBreak => write!(f, "Break in array literal not supported"),
+            Self::VarNotFound(name) => write!(f, "Variable {name} not found in scope"),
+            Self::FnNotFound(name) => write!(f, "Function {name} not found in scope"),
+            Self::ArrayOutOfBounds(idx, len) => write!(
+                f,
+                "ArrayRef index out of range: {idx} is larger than array length {len}"
+            ),
+            Self::TupleOutOfBounds(idx, len) => write!(
+                f,
+                "Tuple index out of range: {idx} is larger than tuple length {len}"
+            ),
+            Self::IndexNonArray => write!(f, "array index must be called for an array"),
+            Self::NeedRef(name) => write!(
+                f,
+                "We need variable reference on lhs to assign. Actually we got {name:?}"
+            ),
+            Self::NoMatchingArg(arg, fun) => write!(
+                f,
+                "No matching named parameter \"{arg}\" is found in function \"{fun}\""
+            ),
+            Self::MissingArg(arg) => write!(f, "No argument is given to \"{arg}\""),
+            Self::BreakInToplevel => write!(f, "break in function toplevel"),
+            Self::BreakInFnArg => write!(f, "Break in function argument is not supported yet!"),
+            Self::NonIntegerIndex => write!(f, "Subscript type should be integer types"),
+            Self::NonIntegerBitwise(val) => {
+                write!(f, "Bitwise operation is not supported for {val}")
+            }
+            Self::NoMainFound => write!(f, "No main function found"),
+            Self::NonNameFnRef(val) => write!(
+                f,
+                "Function can be only specified by a name (yet), but got {val}"
+            ),
+            Self::CallStackUndeflow => write!(f, "Call stack underflow!"),
+            Self::IncompatibleArrayLength(dst, src) => write!(
+                f,
+                "Array length is incompatible; tried to assign {src} to {dst}"
+            ),
+            Self::AssignToLiteral(name) => write!(f, "Cannot assign to a literal: {}", name),
+            Self::IndexNonNum => write!(f, "Indexed an array with a non-number"),
+            Self::NonLValue(ex) => write!(f, "Expression {} is not an lvalue.", ex),
+            Self::PrematureEnd => {
+                write!(f, "End of input bytecode encountered before seeing a Ret")
+            }
+            Self::WrongArgType(arg, expected) => {
+                write!(f, "Argument {arg} type expected {expected}")
+            }
+            Self::IOError(e) => e.fmt(f),
+            Self::ValueError(e) => e.fmt(f),
+            Self::NoStructFound(name) => write!(f, "Struct {name} not found"),
+            Self::NoFieldFound(name) => write!(f, "Field {name} not found"),
+            Self::TypeCheck(name) => write!(f, "Type check error: {name}"),
+            Self::ExpectStruct(ty) => write!(f, "Expect a struct, but got a {ty}"),
+        }
+    }
+}
+
+impl From<String> for EvalError {
+    fn from(value: String) -> Self {
+        Self::Other(value)
+    }
+}
+
+impl From<std::io::Error> for EvalError {
+    fn from(value: std::io::Error) -> Self {
+        Self::IOError(value)
+    }
+}

--- a/parser/src/format_ast.rs
+++ b/parser/src/format_ast.rs
@@ -127,6 +127,11 @@ pub fn format_expr(
             write!(f, ".{}", idx)?;
             Ok(())
         }
+        ExprEnum::FieldAccess(ex, field_name) => {
+            format_expr(ex, level, f)?;
+            write!(f, ".{}", field_name)?;
+            Ok(())
+        }
         ExprEnum::Brace(stmts) => {
             for stmt in stmts {
                 format_stmt(stmt, level + 1, f)?;

--- a/parser/src/format_ast.rs
+++ b/parser/src/format_ast.rs
@@ -12,7 +12,7 @@ pub fn format_expr(
     match &ex.expr {
         ExprEnum::NumLiteral(num, ts) => write!(f, "{num}{}", format_tsa(ts)),
         ExprEnum::StrLiteral(s) => write!(f, "\"{s}\""), // TODO: escape
-        ExprEnum::StructLiteral(name, fields) => {
+        ExprEnum::StructLiteral { name, fields, .. } => {
             let indent = "  ".repeat(level);
             writeln!(f, "{name} {{")?;
             for field in fields {
@@ -127,9 +127,17 @@ pub fn format_expr(
             write!(f, ".{}", idx)?;
             Ok(())
         }
-        ExprEnum::FieldAccess(ex, field_name) => {
-            format_expr(ex, level, f)?;
-            write!(f, ".{}", field_name)?;
+        ExprEnum::FieldAccess {
+            prefix,
+            postfix,
+            def,
+        } => {
+            format_expr(prefix, level, f)?;
+            if let Some(def) = def.as_ref() {
+                write!(f, "({}).{}", def.name, postfix)?;
+            } else {
+                write!(f, ".{}", postfix)?;
+            }
             Ok(())
         }
         ExprEnum::Brace(stmts) => {

--- a/parser/src/format_ast.rs
+++ b/parser/src/format_ast.rs
@@ -246,6 +246,14 @@ pub fn format_stmt(
             Ok(())
         }
         Statement::Break => write!(f, "{indent}break;"),
+        Statement::Struct(str) => {
+            writeln!(f, "struct {} {{", str.name)?;
+            for field in &str.fields {
+                writeln!(f, "{}: {}", field.name, field.ty)?;
+            }
+            writeln!(f, "}}")?;
+            Ok(())
+        }
     }
 }
 

--- a/parser/src/format_ast.rs
+++ b/parser/src/format_ast.rs
@@ -12,6 +12,16 @@ pub fn format_expr(
     match &ex.expr {
         ExprEnum::NumLiteral(num, ts) => write!(f, "{num}{}", format_tsa(ts)),
         ExprEnum::StrLiteral(s) => write!(f, "\"{s}\""), // TODO: escape
+        ExprEnum::StructLiteral(name, fields) => {
+            let indent = "  ".repeat(level);
+            writeln!(f, "{name} {{")?;
+            for field in fields {
+                write!(f, "{indent}  {}: ", field.0)?;
+                format_expr(&field.1, level, f)?;
+                writeln!(f, ",")?;
+            }
+            write!(f, "{indent}}}")
+        }
         ExprEnum::Variable(name) => write!(f, "{name}"),
         ExprEnum::VarAssign(lhs, rhs) => {
             format_expr(lhs, level, f)?;

--- a/parser/src/interpreter.rs
+++ b/parser/src/interpreter.rs
@@ -223,6 +223,7 @@ where
                     }
                 }
                 LValue::ArrayRef(arr, idx) => arr.borrow_mut().values[idx] = rhs_value.clone(),
+                LValue::StructRef(st, idx) => st.borrow_mut().fields[idx] = rhs_value.clone(),
             }
             RunResult::Yield(rhs_value)
         }

--- a/parser/src/interpreter.rs
+++ b/parser/src/interpreter.rs
@@ -4,9 +4,10 @@ use self::lvalue::{eval_lvalue, LValue};
 
 use crate::{
     coercion::{coerce_f64, coerce_i64, coerce_type},
+    eval_error::EvalError,
     parser::*,
     type_decl::ArraySize,
-    value::{ArrayInt, StructInt, TupleEntry, ValueError},
+    value::{ArrayInt, StructInt, TupleEntry},
     TypeDecl, Value,
 };
 use std::{cell::RefCell, collections::HashMap, convert::TryInto, io::Write, rc::Rc};
@@ -18,148 +19,6 @@ pub enum RunResult {
 }
 
 pub type EvalResult<T> = Result<T, EvalError>;
-
-/// Error type for the AST intepreter and bytecode interpreter.
-/// Note that it is shared among 2 kinds of interpreters, so some of them only happen in either kind.
-/// Also note that it is supposed to be displayed with Display or "{}" format, not with Debug or "{:?}".
-///
-/// It owns the value so it is not bounded by a lifetime.
-/// The information about the error shold be converted to a string (by `format!("{:?}")`) before wrapping it
-/// into `EvalError`.
-#[non_exhaustive]
-#[derive(Debug)]
-pub enum EvalError {
-    Other(String),
-    CoerceError(String, String),
-    OpError(String, String),
-    CmpError(String, String),
-    FloatOpError(String, String),
-    StrOpError(String, String),
-    DisallowedBreak,
-    VarNotFound(String),
-    FnNotFound(String),
-    ArrayOutOfBounds(usize, usize),
-    TupleOutOfBounds(usize, usize),
-    IndexNonArray,
-    NeedRef(String),
-    NoMatchingArg(String, String),
-    MissingArg(String),
-    BreakInToplevel,
-    BreakInFnArg,
-    NonIntegerIndex,
-    NonIntegerBitwise(String),
-    NoMainFound,
-    NonNameFnRef(String),
-    CallStackUndeflow,
-    IncompatibleArrayLength(usize, usize),
-    AssignToLiteral(String),
-    IndexNonNum,
-    NonLValue(String),
-    PrematureEnd,
-    WrongArgType(String, String),
-    IOError(std::io::Error),
-    ValueError(ValueError),
-    NoStructFound(String),
-    NoFieldFound(String),
-    TypeCheck(String),
-    ExpectStruct(TypeDecl),
-}
-
-impl std::convert::From<ValueError> for EvalError {
-    fn from(value: ValueError) -> Self {
-        Self::ValueError(value)
-    }
-}
-
-impl std::error::Error for EvalError {}
-
-impl std::fmt::Display for EvalError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Other(e) => write!(f, "Unknown error: {e}"),
-            Self::CoerceError(from, to) => {
-                write!(f, "Coercing from {from:?} to {to:?} is disallowed")
-            }
-            Self::OpError(lhs, rhs) => {
-                write!(f, "Unsupported operation between {lhs:?} and {rhs:?}")
-            }
-            Self::CmpError(lhs, rhs) => {
-                write!(f, "Unsupported comparison between {lhs:?} and {rhs:?}",)
-            }
-            Self::FloatOpError(lhs, rhs) => {
-                write!(f, "Unsupported float operation between {lhs:?} and {rhs:?}")
-            }
-            Self::StrOpError(lhs, rhs) => write!(
-                f,
-                "Unsupported string operation between {lhs:?} and {rhs:?}"
-            ),
-            Self::DisallowedBreak => write!(f, "Break in array literal not supported"),
-            Self::VarNotFound(name) => write!(f, "Variable {name} not found in scope"),
-            Self::FnNotFound(name) => write!(f, "Function {name} not found in scope"),
-            Self::ArrayOutOfBounds(idx, len) => write!(
-                f,
-                "ArrayRef index out of range: {idx} is larger than array length {len}"
-            ),
-            Self::TupleOutOfBounds(idx, len) => write!(
-                f,
-                "Tuple index out of range: {idx} is larger than tuple length {len}"
-            ),
-            Self::IndexNonArray => write!(f, "array index must be called for an array"),
-            Self::NeedRef(name) => write!(
-                f,
-                "We need variable reference on lhs to assign. Actually we got {name:?}"
-            ),
-            Self::NoMatchingArg(arg, fun) => write!(
-                f,
-                "No matching named parameter \"{arg}\" is found in function \"{fun}\""
-            ),
-            Self::MissingArg(arg) => write!(f, "No argument is given to \"{arg}\""),
-            Self::BreakInToplevel => write!(f, "break in function toplevel"),
-            Self::BreakInFnArg => write!(f, "Break in function argument is not supported yet!"),
-            Self::NonIntegerIndex => write!(f, "Subscript type should be integer types"),
-            Self::NonIntegerBitwise(val) => {
-                write!(f, "Bitwise operation is not supported for {val}")
-            }
-            Self::NoMainFound => write!(f, "No main function found"),
-            Self::NonNameFnRef(val) => write!(
-                f,
-                "Function can be only specified by a name (yet), but got {val}"
-            ),
-            Self::CallStackUndeflow => write!(f, "Call stack underflow!"),
-            Self::IncompatibleArrayLength(dst, src) => write!(
-                f,
-                "Array length is incompatible; tried to assign {src} to {dst}"
-            ),
-            Self::AssignToLiteral(name) => write!(f, "Cannot assign to a literal: {}", name),
-            Self::IndexNonNum => write!(f, "Indexed an array with a non-number"),
-            Self::NonLValue(ex) => write!(f, "Expression {} is not an lvalue.", ex),
-            Self::PrematureEnd => {
-                write!(f, "End of input bytecode encountered before seeing a Ret")
-            }
-            Self::WrongArgType(arg, expected) => {
-                write!(f, "Argument {arg} type expected {expected}")
-            }
-            Self::IOError(e) => e.fmt(f),
-            Self::ValueError(e) => e.fmt(f),
-            Self::NoStructFound(name) => write!(f, "Struct {name} not found"),
-            Self::NoFieldFound(name) => write!(f, "Field {name} not found"),
-            Self::TypeCheck(name) => write!(f, "Type check error: {name}"),
-            Self::ExpectStruct(ty) => write!(f, "Expect a struct, but got a {ty}"),
-        }
-    }
-}
-
-impl From<String> for EvalError {
-    fn from(value: String) -> Self {
-        Self::Other(value)
-    }
-}
-
-impl From<std::io::Error> for EvalError {
-    fn from(value: std::io::Error) -> Self {
-        Self::IOError(value)
-    }
-}
 
 /// An extension trait for `Vec` to write a shorthand for
 /// `values.get(idx).ok_or_else(|| EvalError::ArrayOutOfBounds(idx, values.len()))`, because

--- a/parser/src/interpreter.rs
+++ b/parser/src/interpreter.rs
@@ -165,8 +165,7 @@ where
         ExprEnum::StructLiteral { name, fields, .. } => {
             // TODO: work around clone for the borrow checker
             let st_ty = ctx
-                .typedefs
-                .get(**name)
+                .get_type(**name)
                 .ok_or_else(|| EvalError::NoStructFound(name.to_string()))?
                 .clone();
 
@@ -343,9 +342,8 @@ where
             let TypeDecl::TypeName(st_name) = st_ty else {
                 return Err(EvalError::TypeCheck("Type must be named".to_string()));
             };
-            let st_ty = ctx
-                .typedefs
-                .get(&st_name)
+            let st_ty = &ctx
+                .get_type(&st_name)
                 .ok_or_else(|| EvalError::NoStructFound(st_name.to_string()))?;
             let (idx, _) = st_ty
                 .fields
@@ -837,6 +835,12 @@ impl<'src, 'ast, 'native, 'ctx> EvalContext<'src, 'native, 'ctx> {
         } else {
             None
         }
+    }
+
+    fn get_type(&self, name: &str) -> Option<&StructDecl<'src>> {
+        self.typedefs
+            .get(name)
+            .or_else(|| self.super_context.and_then(|sc| sc.get_type(name)))
     }
 }
 

--- a/parser/src/interpreter.rs
+++ b/parser/src/interpreter.rs
@@ -162,7 +162,7 @@ where
                 })
                 .collect::<Result<Vec<_>, _>>()?,
         ))),
-        ExprEnum::StructLiteral(name, fields) => {
+        ExprEnum::StructLiteral { name, fields, .. } => {
             // TODO: work around clone for the borrow checker
             let st_ty = ctx
                 .typedefs
@@ -332,7 +332,11 @@ where
             let result = unwrap_run!(eval(ex, ctx)?);
             RunResult::Yield(result.tuple_get(*index as u64)?)
         }
-        ExprEnum::FieldAccess(ex, field_name) => {
+        ExprEnum::FieldAccess {
+            prefix: ex,
+            postfix: field_name,
+            ..
+        } => {
             let result = unwrap_run!(eval(ex, ctx)?);
 
             let st_ty = TypeDecl::from_value(&result);
@@ -758,6 +762,7 @@ impl<'src, 'native> FuncDef<'src, 'native> {
 }
 
 pub(crate) type TypeMap<'src> = HashMap<String, StructDecl<'src>>;
+pub(crate) type TypeMapRc<'src> = HashMap<String, Rc<StructDecl<'src>>>;
 
 /// A context stat for evaluating a script.
 ///

--- a/parser/src/interpreter/lvalue.rs
+++ b/parser/src/interpreter/lvalue.rs
@@ -95,7 +95,11 @@ where
                 }
             })
         }
-        FieldAccess(ex, field_name) => {
+        FieldAccess {
+            prefix: ex,
+            postfix: field_name,
+            ..
+        } => {
             let val = eval_lvalue(ex, ctx)?;
 
             let resolve_struct = |var: &Value| {

--- a/parser/src/interpreter/test.rs
+++ b/parser/src/interpreter/test.rs
@@ -68,7 +68,7 @@ fn parens_eval_test() {
 #[test]
 fn var_ident_test() {
     let span = Span::new(" x123 ");
-    let res = var_ref(span).finish().unwrap().1;
+    let res = _var_ref(span).finish().unwrap().1;
     assert_eq!(res, Expression::new(Variable("x123"), span.subslice(1, 4)));
 }
 

--- a/parser/src/interpreter/test.rs
+++ b/parser/src/interpreter/test.rs
@@ -804,7 +804,7 @@ fn array_sized_error_test() {
         Ok(_) => panic!(),
         Err(e) => assert_eq!(
             e.to_string(),
-            "Array size is not compatible: 4 cannot assign to 3\ninput:1:56"
+            "Array size is not compatible: 4 cannot assign to 3\ninput:1:57"
         ),
     }
     // It will run successfully although the typecheck fails.

--- a/parser/src/iter_types.rs
+++ b/parser/src/iter_types.rs
@@ -66,7 +66,7 @@ pub fn iter_types(ast: &[Statement], f: &mut impl FnMut(TypeParams)) {
                 iter_types_expr(end, f);
                 iter_types(stmts, f);
             }
-            Statement::Break => (),
+            Statement::Break | Statement::Struct(_) => (),
         }
     }
 }

--- a/parser/src/iter_types.rs
+++ b/parser/src/iter_types.rs
@@ -114,6 +114,7 @@ fn iter_types_expr(ex: &Expression, f: &mut impl FnMut(TypeParams)) {
             }
         }
         ExprEnum::TupleIndex(ex, _)
+        | ExprEnum::FieldAccess(ex, _)
         | ExprEnum::Not(ex)
         | ExprEnum::BitNot(ex)
         | ExprEnum::Neg(ex) => {

--- a/parser/src/iter_types.rs
+++ b/parser/src/iter_types.rs
@@ -83,7 +83,7 @@ fn iter_types_expr(ex: &Expression, f: &mut impl FnMut(TypeParams)) {
                 });
             }
         }
-        ExprEnum::StructLiteral(_, fields) => {
+        ExprEnum::StructLiteral { fields, .. } => {
             for (_, field_ex) in fields {
                 iter_types_expr(field_ex, f);
             }
@@ -114,7 +114,7 @@ fn iter_types_expr(ex: &Expression, f: &mut impl FnMut(TypeParams)) {
             }
         }
         ExprEnum::TupleIndex(ex, _)
-        | ExprEnum::FieldAccess(ex, _)
+        | ExprEnum::FieldAccess { prefix: ex, .. }
         | ExprEnum::Not(ex)
         | ExprEnum::BitNot(ex)
         | ExprEnum::Neg(ex) => {

--- a/parser/src/iter_types.rs
+++ b/parser/src/iter_types.rs
@@ -83,6 +83,19 @@ fn iter_types_expr(ex: &Expression, f: &mut impl FnMut(TypeParams)) {
                 });
             }
         }
+        ExprEnum::StructLiteral(_, fields) => {
+            for (_, field_ex) in fields {
+                iter_types_expr(field_ex, f);
+            }
+            // if let Some(RetType::Some(ty)) = fields.determine() {
+            //     f(TypeParams {
+            //         span: ex.span,
+            //         ty: &ty,
+            //         annotated: false,
+            //         literal: true,
+            //     });
+            // }
+        }
         ExprEnum::StrLiteral(_)
         | ExprEnum::ArrLiteral(_)
         | ExprEnum::TupleLiteral(_)

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -9,6 +9,7 @@ macro_rules! dbg_println {
 mod bytecode;
 mod coercion;
 mod compiler;
+mod eval_error;
 mod format_ast;
 mod interpreter;
 mod iter_types;
@@ -29,8 +30,9 @@ pub use self::bytecode::{
 };
 pub use self::coercion::coerce_type;
 pub use self::compiler::*;
+pub use self::eval_error::EvalError;
 pub use self::format_ast::format_stmts;
-pub use self::interpreter::{run, EvalContext, EvalError, FuncDef, RunResult};
+pub use self::interpreter::{run, EvalContext, FuncDef, RunResult};
 pub use self::iter_types::{iter_types, TypeParams};
 pub use self::parser::{span_source as source, ArgDecl, ReadError, Span};
 pub use self::type_decl::TypeDecl;

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -30,7 +30,7 @@ pub use self::bytecode::{
 pub use self::coercion::coerce_type;
 pub use self::compiler::*;
 pub use self::format_ast::format_stmts;
-pub use self::interpreter::{run, EvalContext, EvalError, FuncDef};
+pub use self::interpreter::{run, EvalContext, EvalError, FuncDef, RunResult};
 pub use self::iter_types::{iter_types, TypeParams};
 pub use self::parser::{span_source as source, ArgDecl, ReadError, Span};
 pub use self::type_decl::TypeDecl;

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -16,7 +16,7 @@ use nom::{
     error::ParseError,
     multi::{fold_many0, many0, many1, separated_list0, separated_list1},
     sequence::{delimited, pair, preceded, terminated, tuple},
-    IResult, InputTake, Offset,
+    IResult, InputTake, Offset, Parser,
 };
 use nom_locate::LocatedSpan;
 use std::{rc::Rc, string::FromUtf8Error};
@@ -322,7 +322,12 @@ fn type_tuple(i: Span) -> IResult<Span, TypeDecl> {
 }
 
 pub(crate) fn type_decl(input: Span) -> IResult<Span, TypeDecl> {
-    alt((type_array, type_tuple, type_scalar))(input)
+    alt((
+        type_array,
+        type_tuple,
+        type_scalar,
+        identifier.map(|id| TypeDecl::TypeName(id.to_string())),
+    ))(input)
 }
 
 fn cast(i: Span) -> IResult<Span, Expression> {

--- a/parser/src/parser/test.rs
+++ b/parser/src/parser/test.rs
@@ -895,3 +895,26 @@ fn test_cmp() {
         assert_eq!(std::str::from_utf8(&buf).unwrap(), &format!("(a {} b)", op));
     }
 }
+
+#[test]
+fn test_struct() {
+    let src = Span::new("struct A { a: i32, b: f64 }");
+    let (r, stmt) = dbg!(statement(src).finish().unwrap());
+    assert!(r.is_empty());
+    assert_eq!(
+        stmt,
+        Statement::Struct(StructDecl {
+            name: src.subslice(7, 1),
+            fields: vec![
+                StructField {
+                    name: src.subslice(11, 1),
+                    ty: TypeDecl::I32,
+                },
+                StructField {
+                    name: src.subslice(19, 1),
+                    ty: TypeDecl::F64,
+                }
+            ]
+        })
+    );
+}

--- a/parser/src/parser/test.rs
+++ b/parser/src/parser/test.rs
@@ -897,9 +897,9 @@ fn test_cmp() {
 }
 
 #[test]
-fn test_struct() {
+fn test_struct_def() {
     let src = Span::new("struct A { a: i32, b: f64 }");
-    let (r, stmt) = dbg!(statement(src).finish().unwrap());
+    let (r, stmt) = statement(src).finish().unwrap();
     assert!(r.is_empty());
     assert_eq!(
         stmt,
@@ -916,5 +916,21 @@ fn test_struct() {
                 }
             ]
         })
+    );
+}
+
+#[test]
+fn test_struct() {
+    let src = Span::new("var a: A;");
+    let (r, stmt) = statement(src).finish().unwrap();
+    assert!(r.is_empty());
+    assert_eq!(
+        stmt,
+        Statement::VarDecl {
+            name: src.subslice(4, 1),
+            ty: TypeDecl::TypeName(src.subslice(7, 1).to_string()),
+            ty_annotated: true,
+            init: None
+        }
     );
 }

--- a/parser/src/type_decl.rs
+++ b/parser/src/type_decl.rs
@@ -21,6 +21,7 @@ pub enum TypeDecl {
     Str,
     Array(Box<TypeDecl>, ArraySize),
     Tuple(Vec<TypeDecl>),
+    TypeName(String),
 }
 
 impl TypeDecl {
@@ -62,6 +63,7 @@ impl TypeDecl {
                 }
                 return Ok(());
             }
+            Self::TypeName(_) => todo!(),
         };
         writer.write_all(&tag.to_le_bytes())?;
         Ok(())
@@ -121,6 +123,7 @@ impl std::fmt::Display for TypeDecl {
                     }
                 })
             )?,
+            Self::TypeName(name) => write!(f, "{name}")?,
         }
         Ok(())
     }

--- a/parser/src/type_decl.rs
+++ b/parser/src/type_decl.rs
@@ -39,6 +39,7 @@ impl TypeDecl {
                     .map(|val| Self::from_value(&val.value))
                     .collect(),
             ),
+            Value::Struct(a) => Self::TypeName(a.borrow().name.clone()),
         }
     }
 

--- a/parser/src/type_infer.rs
+++ b/parser/src/type_infer.rs
@@ -809,7 +809,8 @@ where
         Statement::Break => {
             // TODO: check types in break out site. For now we disallow break with values like Rust.
         }
-        Statement::Comment(_) => (),
+        // Struct should be definitely typed, until we have generic types.
+        Statement::Struct(_) | Statement::Comment(_) => (),
     }
     Ok(res)
 }
@@ -901,7 +902,8 @@ where
         Statement::Break => {
             // TODO: check types in break out site. For now we disallow break with values like Rust.
         }
-        Statement::Comment(_) => (),
+        // Struct should be definitely typed, until we have generic types.
+        Statement::Struct(_) | Statement::Comment(_) => (),
     }
     Ok(())
 }

--- a/parser/src/type_infer.rs
+++ b/parser/src/type_infer.rs
@@ -879,7 +879,10 @@ where
             // TODO: check types in break out site. For now we disallow break with values like Rust.
         }
         // Struct should be definitely typed, until we have generic types.
-        Statement::Struct(_) | Statement::Comment(_) => (),
+        Statement::Struct(st) => {
+            ctx.typedefs.insert(st.name.to_string(), st.clone());
+        }
+        Statement::Comment(_) => (),
     }
     Ok(res)
 }

--- a/parser/src/type_infer.rs
+++ b/parser/src/type_infer.rs
@@ -34,6 +34,8 @@ impl<'src> Display for TypeCheckError<'src> {
     }
 }
 
+impl<'src> std::error::Error for TypeCheckError<'src> {}
+
 impl<'src> TypeCheckError<'src> {
     fn new(msg: impl Into<String>, span: Span<'src>, source_file: Option<&'src str>) -> Self {
         Self {

--- a/parser/src/type_infer.rs
+++ b/parser/src/type_infer.rs
@@ -580,28 +580,13 @@ where
 
             *def = Some(struct_decl.clone());
 
-            if let Some(tuple) = ts.and_then(|ts| ts.tuple.as_ref()) {
-                if tuple.len() != fields.len() {
-                    return Err(TypeCheckError::new(
-                        format!(
-                            "Tuple sizes are not the same: {} != {}",
-                            tuple.len(),
-                            fields.len()
-                        ),
-                        span,
-                        ctx.source_file,
-                    ));
-                }
-                for (field_name, field) in fields.iter_mut() {
-                    let decl = struct_decl
-                        .fields
-                        .iter()
-                        .find(|field_decl| *field_decl.name == **field_name)
-                        .ok_or_else(|| {
-                            TypeCheckError::undefined_field(*field_name, ctx.source_file)
-                        })?;
-                    tc_expr_reverse(field, &TypeSet::from(&decl.ty), ctx)?;
-                }
+            for (field_name, field) in fields.iter_mut() {
+                let decl = struct_decl
+                    .fields
+                    .iter()
+                    .find(|field_decl| *field_decl.name == **field_name)
+                    .ok_or_else(|| TypeCheckError::undefined_field(*field_name, ctx.source_file))?;
+                tc_expr_reverse(field, &TypeSet::from(&decl.ty), ctx)?;
             }
         }
         ExprEnum::Variable(name) => {

--- a/parser/src/type_infer.rs
+++ b/parser/src/type_infer.rs
@@ -299,7 +299,7 @@ where
         }
         ExprEnum::Cast(_ex, decl) => decl.into(),
         ExprEnum::VarAssign(lhs, rhs) => {
-            let span = e.span;
+            let span = lhs.span;
             if let Some((var_ref, decl_ty)) = forward_lvalue(lhs, ctx)
                 .map_err(|err| TypeCheckError::new(err, span, ctx.source_file))?
             {
@@ -823,12 +823,7 @@ fn forward_lvalue<'src, 'b, 'native>(
                         .fields
                         .iter()
                         .find(|field| *field.name == **field_name)
-                        .ok_or_else(|| {
-                            format!(
-                                "TypeCheckError::field not found({}, {:?})",
-                                ex.span, ctx.source_file
-                            )
-                        })?;
+                        .ok_or_else(|| format!("field {} not found", field_name))?;
                     // We make sure that the struct and the field exists, but we do not apply type constraints by lvalue,
                     // because field types should be determined without inference.
                     Ok(None)

--- a/parser/src/type_set.rs
+++ b/parser/src/type_set.rs
@@ -191,6 +191,7 @@ impl TypeSet {
                     && !set.void
                     && set.array.is_none()
                     && set.tuple.is_none()
+                    && set.type_name.is_empty()
             }
         }
     }
@@ -243,6 +244,8 @@ impl TypeSet {
                         .map(|a| a.determine().and_then(|d| d.as_opt().cloned()))
                         .collect::<Option<_>>()?;
                     return Some(RetType::Some(TypeDecl::Tuple(type_sets)));
+                } else if let Some(tn) = set.type_name.first().cloned() {
+                    return Some(RetType::Some(TypeDecl::TypeName(tn)));
                 }
             }
         }

--- a/parser/src/type_set.rs
+++ b/parser/src/type_set.rs
@@ -523,9 +523,9 @@ impl std::fmt::Display for TypeSetFlags {
             )?;
         }
 
-        // for st in &self.structs {
-        //     write_ty(true, st)?;
-        // }
+        for tn in &self.type_name {
+            write_ty(true, tn)?;
+        }
 
         if !written {
             write!(f, "(none)")?;

--- a/parser/src/type_tags.rs
+++ b/parser/src/type_tags.rs
@@ -5,3 +5,4 @@ pub(crate) const I32_TAG: u8 = 3;
 pub(crate) const STR_TAG: u8 = 4;
 pub(crate) const ARRAY_TAG: u8 = 5;
 pub(crate) const TUPLE_TAG: u8 = 6;
+pub(crate) const STRUCT_TAG: u8 = 7;

--- a/parser/src/value.rs
+++ b/parser/src/value.rs
@@ -43,6 +43,7 @@ pub enum Value {
     Str(String),
     Array(Rc<RefCell<ArrayInt>>),
     Tuple(Rc<RefCell<TupleInt>>),
+    Struct(Rc<RefCell<StructInt>>),
 }
 
 impl Default for Value {
@@ -81,6 +82,21 @@ impl std::fmt::Display for Value {
                     }
                 })
             ),
+            Self::Struct(v) => {
+                let borrow = v.borrow();
+                write!(
+                    f,
+                    "{}({})",
+                    borrow.name,
+                    &borrow.fields.iter().fold("".to_string(), |acc, cur| {
+                        if acc.is_empty() {
+                            cur.to_string()
+                        } else {
+                            acc + ", " + &cur.to_string()
+                        }
+                    })
+                )
+            }
         }
     }
 }
@@ -126,6 +142,17 @@ impl Value {
                 for entry in values.iter() {
                     entry.decl.serialize(writer)?;
                     entry.value.serialize(writer)?;
+                }
+                Ok(())
+            }
+            Self::Struct(rc) => {
+                let values = rc.borrow();
+                writer.write_all(&STRUCT_TAG.to_le_bytes())?;
+                writer.write_all(&(values.name.len() as u32).to_le_bytes())?;
+                writer.write_all(values.name.as_bytes())?;
+                writer.write_all(&values.fields.len().to_le_bytes())?;
+                for value in values.fields.iter() {
+                    value.serialize(writer)?;
                 }
                 Ok(())
             }
@@ -250,6 +277,21 @@ impl Value {
         })
     }
 
+    pub fn struct_field(&self, field_idx: u64) -> Result<Value, EvalError> {
+        Ok(match self {
+            Value::Struct(str) => {
+                let str = str.borrow();
+                str.fields
+                    .get(field_idx as usize)
+                    .ok_or_else(|| {
+                        EvalError::TupleOutOfBounds(field_idx as usize, str.fields.len())
+                    })?
+                    .clone()
+            }
+            _ => return Err(EvalError::ExpectStruct(TypeDecl::from_value(self))),
+        })
+    }
+
     pub fn deepclone(&self) -> Self {
         match self {
             Self::Array(a) => {
@@ -311,6 +353,13 @@ impl std::convert::TryFrom<&Value> for usize {
                     TypeDecl::I64,
                 ))
             }
+            Value::Struct(rc) => {
+                let str = rc.borrow();
+                Err(ValueError::Invalid(
+                    TypeDecl::TypeName(str.name.clone()),
+                    TypeDecl::I64,
+                ))
+            }
         }
     }
 }
@@ -327,6 +376,13 @@ impl TupleEntry {
     pub fn value(&self) -> &Value {
         &self.value
     }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct StructInt {
+    /// Type name of the struct
+    pub(crate) name: String,
+    pub(crate) fields: Vec<Value>,
 }
 
 #[derive(Debug)]

--- a/parser/src/value.rs
+++ b/parser/src/value.rs
@@ -385,6 +385,15 @@ pub struct StructInt {
     pub(crate) fields: Vec<Value>,
 }
 
+impl StructInt {
+    pub fn get(&self, idx: usize) -> EvalResult<Value> {
+        self.fields
+            .get(idx)
+            .ok_or_else(|| EvalError::ArrayOutOfBounds(self.fields.len(), idx))
+            .cloned()
+    }
+}
+
 #[derive(Debug)]
 pub enum ValueError {
     Domain,

--- a/parser/src/value.rs
+++ b/parser/src/value.rs
@@ -396,6 +396,10 @@ impl StructInt {
             .ok_or_else(|| EvalError::ArrayOutOfBounds(self.fields.len(), idx))
             .cloned()
     }
+
+    pub fn fields(&self) -> &[Value] {
+        &self.fields
+    }
 }
 
 #[derive(Debug)]

--- a/parser/src/value.rs
+++ b/parser/src/value.rs
@@ -222,6 +222,9 @@ impl Value {
             Value::Array(array) => {
                 *array.borrow_mut().values.eget_mut(idx)? = value;
             }
+            Value::Struct(st) => {
+                *st.borrow_mut().fields.eget_mut(idx)? = value;
+            }
             _ => return Err(EvalError::IndexNonArray),
         }
         Ok(())
@@ -230,6 +233,7 @@ impl Value {
     pub fn array_get(&self, idx: u64) -> EvalResult<Value> {
         match self {
             Value::Array(array) => Ok(array.borrow_mut().values.eget(idx as usize)?.clone()),
+            Value::Struct(st) => Ok(st.borrow_mut().fields.eget(idx as usize)?.clone()),
             _ => Err(EvalError::IndexNonArray),
         }
     }

--- a/parser/src/vm.rs
+++ b/parser/src/vm.rs
@@ -5,8 +5,9 @@ use std::{cell::RefCell, collections::HashMap, io::Write, rc::Rc};
 use crate::{
     bytecode::{Bytecode, FnBytecode, FnProto, FnProtos, OpCode},
     coercion::{coerce_i64, coerce_type},
+    eval_error::EvalError,
     interpreter::{
-        binary_op, binary_op_int, binary_op_str, compare_op, truthy, EvalError, EvalResult, TypeMap,
+        binary_op, binary_op_int, binary_op_str, compare_op, truthy, EvalResult, TypeMap,
     },
     type_decl::TypeDecl,
     value::TupleEntry,

--- a/parser/src/vm.rs
+++ b/parser/src/vm.rs
@@ -6,7 +6,7 @@ use crate::{
     bytecode::{Bytecode, FnBytecode, FnProto, FnProtos, OpCode},
     coercion::{coerce_i64, coerce_type},
     interpreter::{
-        binary_op, binary_op_int, binary_op_str, compare_op, truthy, EvalError, EvalResult,
+        binary_op, binary_op_int, binary_op_str, compare_op, truthy, EvalError, EvalResult, TypeMap,
     },
     type_decl::TypeDecl,
     Value,
@@ -500,7 +500,7 @@ impl<'a> Vm<'a> {
                 let tt_buf = target_type.to_le_bytes();
                 let tt = TypeDecl::deserialize(&mut &tt_buf[..])
                     .map_err(|e| format!("arg1 of Cast was not a TypeDecl: {e:?}"))?;
-                let new_val = coerce_type(target_var, &tt)?;
+                let new_val = coerce_type(target_var, &tt, &TypeMap::new())?;
                 self.set(inst.arg0, new_val);
             }
         }

--- a/parser/src/vm.rs
+++ b/parser/src/vm.rs
@@ -6,9 +6,7 @@ use crate::{
     bytecode::{Bytecode, FnBytecode, FnProto, FnProtos, OpCode},
     coercion::{coerce_i64, coerce_type},
     eval_error::EvalError,
-    interpreter::{
-        binary_op, binary_op_int, binary_op_str, compare_op, truthy, EvalResult, TypeMap,
-    },
+    interpreter::{binary_op, binary_op_int, binary_op_str, compare_op, truthy, EvalResult},
     type_decl::TypeDecl,
     value::TupleEntry,
     Value,
@@ -502,7 +500,7 @@ impl<'a> Vm<'a> {
                 let tt_buf = target_type.to_le_bytes();
                 let tt = TypeDecl::deserialize(&mut &tt_buf[..])
                     .map_err(|e| format!("arg1 of Cast was not a TypeDecl: {e:?}"))?;
-                let new_val = coerce_type(target_var, &tt, &TypeMap::new())?;
+                let new_val = coerce_type(target_var, &tt)?;
                 self.set(inst.arg0, new_val);
             }
             OpCode::MakeTuple => {

--- a/parser/src/vm.rs
+++ b/parser/src/vm.rs
@@ -392,7 +392,7 @@ impl<'a> Vm<'a> {
                 self.set(inst.arg1, new_val);
             }
             OpCode::Set => {
-                let target_collection = &self.get(inst.arg0);
+                let target_collection = self.get(inst.arg0);
                 let value = self.get(inst.arg1);
                 let index = self.set_register;
                 target_collection.array_assign(index, value.clone())?;

--- a/scripts/struct.dragon
+++ b/scripts/struct.dragon
@@ -5,6 +5,10 @@ struct S {
     c: f64
 }
 
-var a: S = (1, "a", 3.14);
+var a: S = S {
+    a: 1,
+    b: "a",
+    c: 3.14
+};
 
 print("a: ", a, type(a));

--- a/scripts/struct.dragon
+++ b/scripts/struct.dragon
@@ -11,4 +11,6 @@ var a = S {
     b: "a",
 };
 
+print(a.a);
+
 print("a: ", a, type(a));

--- a/scripts/struct.dragon
+++ b/scripts/struct.dragon
@@ -5,10 +5,10 @@ struct S {
     c: f64
 }
 
-var a: S = S {
+var a = S {
     a: 1,
+    c: 3.14,
     b: "a",
-    c: 3.14
 };
 
 print("a: ", a, type(a));

--- a/scripts/struct.dragon
+++ b/scripts/struct.dragon
@@ -5,6 +5,6 @@ struct S {
     c: f64
 }
 
-var a: (i32, str, f64) = (1, "a", 3.14);
+var a: S = (1, "a", 3.14);
 
 print("a: ", a, type(a));

--- a/scripts/struct.dragon
+++ b/scripts/struct.dragon
@@ -1,0 +1,10 @@
+
+struct S {
+    a: i32,
+    b: str,
+    c: f64
+}
+
+var a: (i32, str, f64) = (1, "a", 3.14);
+
+print("a: ", a, type(a));

--- a/scripts/struct.dragon
+++ b/scripts/struct.dragon
@@ -8,11 +8,11 @@ struct S {
 var a = S {
     a: 1,
     c: 3.14,
-    b: "a",
+    b: "Hello",
 };
 
-print(a.a);
+print(a.b);
 
-a.a = 42;
+// a.a = 42;
 
 print("a: ", a, type(a));

--- a/scripts/struct.dragon
+++ b/scripts/struct.dragon
@@ -11,8 +11,8 @@ var a = S {
     b: "Hello",
 };
 
-print(a.b);
+print(a.a);
 
-// a.a = 42;
+a.a = 42;
 
 print("a: ", a, type(a));

--- a/scripts/struct.dragon
+++ b/scripts/struct.dragon
@@ -13,4 +13,6 @@ var a = S {
 
 print(a.a);
 
+a.a = 42;
+
 print("a: ", a, type(a));

--- a/scripts/struct_infer.dragon
+++ b/scripts/struct_infer.dragon
@@ -1,0 +1,8 @@
+struct A {
+    int: i32,
+}
+
+fn main() -> i32 {
+    var a = A { int: 42 };
+    a.int
+}

--- a/scripts/struct_nested.dragon
+++ b/scripts/struct_nested.dragon
@@ -1,0 +1,25 @@
+struct Vec2 {
+    x: f64,
+    y: f64,
+}
+
+struct Mat {
+    w: Vec2,
+    z: Vec2,
+}
+
+fn format_vec(s: Vec2) -> str {
+    (s.x) as str + ", " + (s.y) as str
+}
+
+fn format_mat(s: Mat) -> str {
+    format_vec(s.w) + ", " + format_vec(s.z)
+}
+
+var m = Mat {
+    w: Vec2 { x: 10., y: 20. },
+    z: Vec2 { x: 30., y: 40. },
+};
+m.z.y = 400.;
+
+print(format_mat(m))

--- a/wasm/js/main.js
+++ b/wasm/js/main.js
@@ -74,6 +74,7 @@ const samples = document.getElementById("samples");
     "typecheck.dragon", "cast.dragon", "cast_error.dragon",
     "pipe.dragon",
     "cmp.dragon",
+    "struct.dragon",
 ]
     .forEach(fileName => {
     const link = document.createElement("a");

--- a/wasm/js/main.js
+++ b/wasm/js/main.js
@@ -74,7 +74,7 @@ const samples = document.getElementById("samples");
     "typecheck.dragon", "cast.dragon", "cast_error.dragon",
     "pipe.dragon",
     "cmp.dragon",
-    "struct.dragon",
+    "struct.dragon", "struct_infer.dragon",
 ]
     .forEach(fileName => {
     const link = document.createElement("a");

--- a/wasm/js/main.js
+++ b/wasm/js/main.js
@@ -74,7 +74,7 @@ const samples = document.getElementById("samples");
     "typecheck.dragon", "cast.dragon", "cast_error.dragon",
     "pipe.dragon",
     "cmp.dragon",
-    "struct.dragon", "struct_infer.dragon",
+    "struct.dragon", "struct_infer.dragon", "struct_nested.dragon",
 ]
     .forEach(fileName => {
     const link = document.createElement("a");

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -160,44 +160,64 @@ pub fn parse_ast(src: &str) -> Result<String, JsValue> {
 
 #[wasm_bindgen]
 pub fn compile(src: &str) -> Result<Vec<u8>, JsValue> {
-    let parse_result =
-        source(src).map_err(|e| JsValue::from_str(&format!("Parse error: {:?}", e)))?;
+    compile_impl(src).map_err(|e| JsValue::from_str(&e.to_string()))
+}
+
+fn compile_impl<'src>(src: &'src str) -> Result<Vec<u8>, Box<dyn std::error::Error + 'src>> {
+    let (_, mut parse_result) = source(src).map_err(|e| format!("Parse error: {:?}", e))?;
     let mut functions = HashMap::new();
     extra_functions(&mut |name, f| {
         functions.insert(name, f);
     });
-    let bytecode = mascal::compile(&parse_result.1, functions)
-        .map_err(|e| JsValue::from_str(&format!("Error: {}", e)))?;
+
+    let mut ctx = TypeCheckContext::new(None);
+    wasm_functions(|name, f| ctx.set_fn(name, f));
+    mascal::type_check(&mut parse_result, &mut ctx)?;
+
+    let bytecode = mascal::compile(&parse_result, functions)?;
     let mut bytes = vec![];
-    bytecode
-        .write(&mut bytes)
-        .map_err(|s| JsValue::from_str(&s.to_string()))?;
+    bytecode.write(&mut bytes)?;
     Ok(bytes)
 }
 
 #[wasm_bindgen]
 pub fn disasm(src: &str) -> Result<String, JsValue> {
-    let parse_result =
-        source(src).map_err(|e| JsValue::from_str(&format!("Parse error: {:?}", e)))?;
+    disasm_impl(src).map_err(|e| JsValue::from_str(&e.to_string()))
+}
+
+fn disasm_impl<'src>(src: &'src str) -> Result<String, Box<dyn std::error::Error + 'src>> {
+    let (_, mut parse_result) = source(src).map_err(|e| format!("Parse error: {:?}", e))?;
     let mut functions = HashMap::new();
+
     extra_functions(&mut |name, f| {
         functions.insert(name, f);
     });
-    let disasm_code = mascal::disasm(&parse_result.1, functions)
-        .map_err(|e| JsValue::from_str(&format!("Error: {}", e)))?;
+
+    let mut ctx = TypeCheckContext::new(None);
+    wasm_functions(|name, f| ctx.set_fn(name, f));
+    mascal::type_check(&mut parse_result, &mut ctx)?;
+
+    let disasm_code = mascal::disasm(&parse_result, functions)?;
     Ok(disasm_code)
 }
 
 #[wasm_bindgen]
 pub fn compile_and_run(src: &str) -> Result<(), JsValue> {
-    let parse_result =
-        source(src).map_err(|e| JsValue::from_str(&format!("Parse error: {:?}", e)))?;
+    compile_and_run_wrap(src).map_err(|e| JsValue::from_str(&e.to_string()))
+}
+
+fn compile_and_run_wrap<'src>(src: &'src str) -> Result<(), Box<dyn std::error::Error + 'src>> {
+    let (_, mut parse_result) = source(src).map_err(|e| format!("Parse error: {:?}", e))?;
     let mut functions = HashMap::new();
     extra_functions(&mut |name, f| {
         functions.insert(name, f);
     });
-    let mut bytecode = mascal::compile(&parse_result.1, functions)
-        .map_err(|e| JsValue::from_str(&format!("Error: {}", e)))?;
+
+    let mut ctx = TypeCheckContext::new(None);
+    wasm_functions(|name, f| ctx.set_fn(name, f));
+    mascal::type_check(&mut parse_result, &mut ctx)?;
+
+    let mut bytecode = mascal::compile(&parse_result, functions)?;
 
     // Give a sink because we don't care (can't care) where to put the output from standard functions.
     // Instead, we override the functions with Wasm aware versions.
@@ -206,7 +226,7 @@ pub fn compile_and_run(src: &str) -> Result<(), JsValue> {
     extra_functions(&mut |name, f| {
         bytecode.add_ext_fn(name, f);
     });
-    interpret(&bytecode).map_err(|e| JsValue::from_str(&e.to_string()))?;
+    interpret(&bytecode)?;
     Ok(())
 }
 

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -56,6 +56,7 @@ fn s_puts(vals: &[Value]) -> Result<Value, EvalError> {
                         .map(|v| v.value().clone())
                         .collect::<Vec<_>>(),
                 ),
+                Value::Struct(val) => puts_inner(val.borrow().fields()),
             }
         }
     }


### PR DESCRIPTION
Structs are basic data structures to organize collection of hetergeneously typed data. Tuples could work in a similar way, but struct fields can be named and ordered arbitrarily.

```
struct S {
    a: i32,
    b: str,
    c: f64
}

var a = S {
    a: 1,
    c: 3.14,
    b: "a",
};

print("a: ", a, type(a));
```

A new value variant `Value::Struct` has been added, which is similar to a tuple but has a name of the struct as a part of it. Unlike common dynamically typed languages, it lays out fields in a contiguous array, because we want to pack as much data into one allocation unit as possible. If the fields are all primitive types, it should be very close to arrays in memory profile.

```rust
#[derive(Clone, Debug, PartialEq)]
pub struct StructInt {
    /// Type name of the struct
    pub(crate) name: String,
    pub(crate) fields: Vec<Value>,
}
```

Many common dynamically typed languages, such as Python, put the fields into hash maps, which is very easy to manage memory-wise, but not super efficient in memory usage. I want to go against the easy way and make it efficient as much as I can. A hash map based collection should be implemented separately, as a dictionary.

As a result, structs in Mascal have purely static data structure. You cannot add fields dynamically or after instantiating. Technically, you could change a type of a field, but static type checker will disallow it. This is also different from Python or many other dynamically typed languages, wihch allows modifing named field containers all you want. It is closer in design to Squirrel, which has immutable class type that disallows adding fields after instantiating.

This static nature of struct is important for optimization in bytecode, such as embedding it in the container, like the stack or an array.

There is a catch though. Since the struct payload only makes sense with struct type information, it should have a reference to a struct type. Currently, it is just the name of the struct. However, if we pursue performance, it should be a reference, either by `Rc` or a universal index, to reduce memory allocations. However, it would be redundant information in compiled bytecode interpreter, because the field index should have been resolved at compile time.

The payload is very much like a tuple, but it is defined as a distinct type, in order to prevent incorrect assignments between tuples and structs. These can be caught by type checker/inferrer though.

## Struct references in AST

Since we need a type information to determine which field has which index, we need to put the reference to the struct in each AST node (called `def` in the definition below). Not all nodes requires that, but at least `StructLiteral` and `FieldAccess` need it. It can be anything as long as it can identify a struct, e.g. struct name could work, but we chose to use an `Rc<StructDecl>`.

```rust
pub(crate) enum ExprEnum<'a> {
    ...
    StructLiteral {
        name: Span<'a>,
        fields: Vec<(Span<'a>, Expression<'a>)>,
        /// A reference to struct definition. It will be filled in type inference pass.
        def: Option<Rc<StructDecl<'a>>>,
    },
    FieldAccess {
        prefix: Box<Expression<'a>>,
        postfix: Span<'a>,
        /// A reference to struct definition. It will be filled in type inference pass.
        def: Option<Rc<StructDecl<'a>>>,
    },
    ...
}
```

Note that `def` is an option, because it is not determined at the first pass. It is filled later by type inference.

## Type inference is mandatory now

Due to the new data structure described above, type inference is mandatory to compile, otherwise it will fail with an undefined reference to a struct. This is structural requirement because it is not obvious from AST node itself which struct is being used with `FieldAccess` operator.

## TODOs

- [x] Allow assignment to a field `a.a = 1` in the compiler
- [x] Allow assignment to a nested field `a.b.c = 1` in the compiler