### PR TITLE
Postfix parser improvement

### DIFF
--- a/parser/src/interpreter.rs
+++ b/parser/src/interpreter.rs
@@ -784,6 +784,17 @@ pub struct EvalContext<'src, 'native, 'ctx> {
     super_context: Option<&'ctx EvalContext<'src, 'native, 'ctx>>,
 }
 
+impl<'src, 'ast, 'native, 'ctx> Default for EvalContext<'src, 'native, 'ctx> {
+    fn default() -> Self {
+        Self {
+            variables: Default::default(),
+            functions: Default::default(),
+            typedefs: Default::default(),
+            super_context: Default::default(),
+        }
+    }
+}
+
 impl<'src, 'ast, 'native, 'ctx> EvalContext<'src, 'native, 'ctx> {
     pub fn new() -> Self {
         Self {

--- a/parser/src/interpreter.rs
+++ b/parser/src/interpreter.rs
@@ -788,7 +788,7 @@ impl<'src, 'ast, 'native, 'ctx> Default for EvalContext<'src, 'native, 'ctx> {
     fn default() -> Self {
         Self {
             variables: Default::default(),
-            functions: Default::default(),
+            functions: std_functions(),
             typedefs: Default::default(),
             super_context: Default::default(),
         }

--- a/parser/src/interpreter/test.rs
+++ b/parser/src/interpreter/test.rs
@@ -20,12 +20,12 @@ fn span_expr<'a, 'b>(s: &'a str) -> IResult<Span, Expression> {
 }
 
 fn eval0(s: &Expression) -> RunResult {
-    let mut ctx = EvalContext::new();
+    let mut ctx = EvalContext::default();
     eval(s, &mut ctx).unwrap()
 }
 
 fn run0(s: &Vec<Statement>) -> Result<RunResult, EvalError> {
-    let mut ctx = EvalContext::new();
+    let mut ctx = EvalContext::default();
     run(s, &mut ctx)
 }
 
@@ -74,7 +74,7 @@ fn var_ident_test() {
 
 #[test]
 fn var_test() {
-    let mut ctx = EvalContext::new();
+    let mut ctx = EvalContext::default();
     ctx.variables
         .borrow_mut()
         .insert("x", Rc::new(RefCell::new(Value::F64(42.))));
@@ -98,7 +98,7 @@ fn bnl(value: Value, span: Span) -> Box<Expression> {
 
 #[test]
 fn var_assign_test() {
-    let mut ctx = EvalContext::new();
+    let mut ctx = EvalContext::default();
     ctx.variables
         .borrow_mut()
         .insert("x", Rc::new(RefCell::new(Value::F64(42.))));
@@ -160,7 +160,7 @@ fn fn_default_test() {
 fn fn_default_failure_test() {
     let span = Span::new("var b = 1; fn f(a: i32 = b) { a; } f()");
     let stmts = source(span).finish().unwrap().1;
-    let Err(err) = run(&stmts, &mut EvalContext::new()) else {
+    let Err(err) = run(&stmts, &mut EvalContext::default()) else {
         panic!("Should error");
     };
     assert!(matches!(err, EvalError::VarNotFound(_)));
@@ -695,7 +695,7 @@ fn array_index_test() {
     use Value::*;
     let span = Span::new("a[1]");
     assert_eq!(
-        array_index(span).finish().unwrap().1,
+        full_expression(span).finish().unwrap().1,
         Expression::new(
             ArrIndex(
                 var_r(span.subslice(0, 1)),
@@ -724,7 +724,7 @@ fn array_index_test() {
 #[test]
 fn array_index_eval_test() {
     use Value::*;
-    let mut ctx = EvalContext::new();
+    let mut ctx = EvalContext::default();
 
     // This is very verbose, but necessary to match against a variable in ctx.variables.
     let ast = span_source("var a: [i32] = [1,3,5]; a[1]").unwrap().1;

--- a/parser/src/interpreter/test.rs
+++ b/parser/src/interpreter/test.rs
@@ -91,7 +91,7 @@ fn var_r(name: Span) -> Box<Expression> {
 /// Boxed numeric literal
 fn bnl(value: Value, span: Span) -> Box<Expression> {
     Box::new(Expression::new(
-        NumLiteral(value, TypeSetAnnotated::int_unannotated()),
+        NumLiteral(value, TypeSetAnnotated::int()),
         span,
     ))
 }
@@ -445,7 +445,7 @@ fn logic_eval_test() {
 
 /// Numeric literal without box
 fn nl(value: Value, span: Span) -> Expression {
-    Expression::new(NumLiteral(value, TypeSetAnnotated::int_unannotated()), span)
+    Expression::new(NumLiteral(value, TypeSetAnnotated::int()), span)
 }
 
 #[test]

--- a/parser/src/interpreter/test.rs
+++ b/parser/src/interpreter/test.rs
@@ -91,7 +91,7 @@ fn var_r(name: Span) -> Box<Expression> {
 /// Boxed numeric literal
 fn bnl(value: Value, span: Span) -> Box<Expression> {
     Box::new(Expression::new(
-        NumLiteral(value, TypeSetAnnotated::int()),
+        NumLiteral(value, TypeSetAnnotated::int_unannotated()),
         span,
     ))
 }
@@ -445,7 +445,7 @@ fn logic_eval_test() {
 
 /// Numeric literal without box
 fn nl(value: Value, span: Span) -> Expression {
-    Expression::new(NumLiteral(value, TypeSetAnnotated::int()), span)
+    Expression::new(NumLiteral(value, TypeSetAnnotated::int_unannotated()), span)
 }
 
 #[test]
@@ -769,14 +769,14 @@ fn array_index_assign_test() {
                         var_r(span.subslice(0, 1)),
                         vec![nl(I64(0), span.subslice(2, 1))]
                     ),
-                    span.subslice(0, 5)
+                    span.subslice(0, 4)
                 )),
                 Box::new(Expression::new(
                     ArrIndex(
                         var_r(span.subslice(7, 1)),
                         vec![nl(I64(0), span.subslice(9, 1))]
                     ),
-                    span.subslice(7, 4)
+                    span.subslice(6, 5)
                 )),
             ),
             span
@@ -1052,14 +1052,8 @@ fn for_test() {
         vec![Statement::For {
             var: span.subslice(5, 1),
             ty: None,
-            start: Expression::new(
-                NumLiteral(Value::I64(0), TypeSetAnnotated::int()),
-                span.subslice(10, 1)
-            ),
-            end: Expression::new(
-                NumLiteral(Value::I64(10), TypeSetAnnotated::int()),
-                span.subslice(13, 2)
-            ),
+            start: nl(Value::I64(0), span.subslice(10, 1)),
+            end: nl(Value::I64(10), span.subslice(13, 2)),
             stmts: vec![expr_semi(Expression::new(
                 FnInvoke("print", vec![FnArg::new(*var_r(span.subslice(24, 1)))],),
                 span.subslice(18, 8)

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -723,6 +723,9 @@ fn struct_literal<'a>(name: Span<'a>, i: Span<'a>) -> IResult<Span<'a>, Expressi
     ));
 }
 
+/// The parameter type for the postfix expression parseers. This tuple contains the state and also the span to parse
+/// next source text. The first element is the beginning of the whole postfix expression, the second is the parsed
+/// prefix expression so far, and the last is the span pointing the next source text.
 type PostfixInput<'src> = (Span<'src>, Expression<'src>, Span<'src>);
 
 fn postfix_expression(i: Span) -> IResult<Span, Expression> {

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -450,8 +450,8 @@ fn double_expr(input: Span) -> IResult<Span, Expression> {
         }
     } else {
         let ty = match value {
-            Value::I64(_) => TypeSetAnnotated::int_unannotated(),
-            _ => TypeSetAnnotated::float_unannotated(),
+            Value::I64(_) => TypeSetAnnotated::int(),
+            _ => TypeSetAnnotated::float(),
         };
         (value, ty)
     };

--- a/parser/src/parser/test.rs
+++ b/parser/src/parser/test.rs
@@ -884,6 +884,84 @@ fn test_nested_array_index() {
 }
 
 #[test]
+fn test_tuple_array_index() {
+    let span = Span::new("a.0[1]");
+    assert_eq!(
+        statement(span).finish().unwrap().1,
+        Statement::Expression {
+            ex: Expression::new(
+                ExprEnum::ArrIndex(
+                    Expression::new(
+                        ExprEnum::TupleIndex(
+                            Expression::new(ExprEnum::Variable("a"), span.subslice(0, 1)).boxed(),
+                            0
+                        ),
+                        span.subslice(0, 3)
+                    )
+                    .boxed(),
+                    vec![Expression::new(int(1), span.subslice(4, 1))]
+                ),
+                span
+            ),
+            semicolon: false,
+        }
+    );
+}
+
+#[test]
+fn test_array_struct_index() {
+    let span = Span::new("a[0].a");
+    assert_eq!(
+        statement(span).finish().unwrap().1,
+        Statement::Expression {
+            ex: Expression::new(
+                ExprEnum::FieldAccess {
+                    prefix: Expression::new(
+                        ExprEnum::ArrIndex(
+                            Expression::new(ExprEnum::Variable("a"), span.subslice(0, 1)).boxed(),
+                            vec![Expression::new(int(0), span.subslice(2, 1))]
+                        ),
+                        span.subslice(0, 4)
+                    )
+                    .boxed(),
+                    postfix: span.subslice(5, 1),
+                    def: None
+                },
+                span
+            ),
+            semicolon: false,
+        }
+    );
+}
+
+#[test]
+fn test_struct_array_index() {
+    let span = Span::new("a.a[0]");
+    assert_eq!(
+        statement(span).finish().unwrap().1,
+        Statement::Expression {
+            ex: Expression::new(
+                ExprEnum::ArrIndex(
+                    Expression::new(
+                        ExprEnum::FieldAccess {
+                            prefix: Expression::new(ExprEnum::Variable("a"), span.subslice(0, 1))
+                                .boxed(),
+                            postfix: span.subslice(2, 1),
+                            def: None,
+                        },
+                        span.subslice(0, 3)
+                    )
+                    .boxed(),
+                    vec![Expression::new(int(0), span.subslice(4, 1))]
+                ),
+                span
+            ),
+            semicolon: false,
+        }
+    );
+}
+
+#[test]
 fn test_void_fn() {
     let span = Span::new("fn returns_void() -> void { print(\"Hello\")}");
     assert_eq!(
@@ -934,14 +1012,8 @@ fn test_expr_cast() {
                 ExprEnum::Cast(
                     Box::new(Expression::new(
                         ExprEnum::Add(
-                            Box::new(Expression::new(
-                                ExprEnum::Variable("a"),
-                                span.subslice(1, 1)
-                            )),
-                            Box::new(Expression::new(
-                                ExprEnum::Variable("b"),
-                                span.subslice(5, 1)
-                            ))
+                            Expression::new(ExprEnum::Variable("a"), span.subslice(1, 1)).boxed(),
+                            Expression::new(ExprEnum::Variable("b"), span.subslice(5, 1)).boxed()
                         ),
                         span.subslice(0, 8)
                     )),

--- a/parser/src/parser/test.rs
+++ b/parser/src/parser/test.rs
@@ -102,7 +102,7 @@ fn i64<'a>(i: i64) -> ExprEnum<'a> {
 
 /// Generic integer literal
 fn int<'a>(i: i64) -> ExprEnum<'a> {
-    ExprEnum::NumLiteral(Value::I64(i), TypeSetAnnotated::int())
+    ExprEnum::NumLiteral(Value::I64(i), TypeSetAnnotated::int_unannotated())
 }
 
 #[test]
@@ -845,10 +845,7 @@ fn test_array_index() {
                         ExprEnum::Variable("a"),
                         span.subslice(0, 1)
                     )),
-                    vec![Expression::new(
-                        ExprEnum::NumLiteral(Value::I64(0), TypeSetAnnotated::int_unannotated()),
-                        span.subslice(2, 1)
-                    )]
+                    vec![Expression::new(int(0), span.subslice(2, 1))]
                 ),
                 span
             ),
@@ -871,20 +868,11 @@ fn test_nested_array_index() {
                                 ExprEnum::Variable("a"),
                                 span.subslice(0, 1)
                             )),
-                            vec![Expression::new(
-                                ExprEnum::NumLiteral(
-                                    Value::I64(0),
-                                    TypeSetAnnotated::int_unannotated()
-                                ),
-                                span.subslice(2, 1)
-                            )]
+                            vec![Expression::new(int(0), span.subslice(2, 1))]
                         ),
                         span.subslice(0, 4)
                     )),
-                    vec![Expression::new(
-                        ExprEnum::NumLiteral(Value::I64(1), TypeSetAnnotated::int_unannotated()),
-                        span.subslice(5, 1)
-                    )]
+                    vec![Expression::new(int(1), span.subslice(5, 1))]
                 ),
                 span
             ),
@@ -913,6 +901,24 @@ fn test_void_fn() {
                 span.subslice(28, 14)
             ))])
         }]
+    );
+}
+
+#[test]
+fn test_fn_call() {
+    let span = Span::new("a(0)");
+    assert_eq!(
+        statement(span).finish().unwrap().1,
+        Statement::Expression {
+            ex: Expression::new(
+                ExprEnum::FnInvoke(
+                    "a",
+                    vec![FnArg::new(Expression::new(int(0), span.subslice(2, 1)))]
+                ),
+                span
+            ),
+            semicolon: false,
+        }
     );
 }
 

--- a/parser/src/parser/test.rs
+++ b/parser/src/parser/test.rs
@@ -108,7 +108,7 @@ fn i64<'a>(i: i64) -> ExprEnum<'a> {
 
 /// Generic integer literal
 fn int<'a>(i: i64) -> ExprEnum<'a> {
-    ExprEnum::NumLiteral(Value::I64(i), TypeSetAnnotated::int_unannotated())
+    ExprEnum::NumLiteral(Value::I64(i), TypeSetAnnotated::int())
 }
 
 #[test]

--- a/parser/src/type_set.rs
+++ b/parser/src/type_set.rs
@@ -78,6 +78,13 @@ impl TypeSetAnnotated {
         }
     }
 
+    pub fn int_unannotated() -> Self {
+        Self {
+            ts: TypeSet::int(),
+            annotated: false,
+        }
+    }
+
     pub fn f32() -> Self {
         Self {
             ts: TypeSet::Set(TypeSetFlags {
@@ -100,11 +107,14 @@ impl TypeSetAnnotated {
 
     pub fn float() -> Self {
         Self {
-            ts: TypeSet::Set(TypeSetFlags {
-                f32: true,
-                f64: true,
-                ..TypeSetFlags::default()
-            }),
+            ts: TypeSet::float(),
+            annotated: true,
+        }
+    }
+
+    pub fn float_unannotated() -> Self {
+        Self {
+            ts: TypeSet::float(),
             annotated: true,
         }
     }
@@ -136,6 +146,14 @@ impl TypeSet {
         TypeSet::Set(TypeSetFlags {
             i32: true,
             i64: true,
+            ..TypeSetFlags::default()
+        })
+    }
+
+    pub fn float() -> Self {
+        Self::Set(TypeSetFlags {
+            f32: true,
+            f64: true,
             ..TypeSetFlags::default()
         })
     }

--- a/parser/src/type_set.rs
+++ b/parser/src/type_set.rs
@@ -74,13 +74,6 @@ impl TypeSetAnnotated {
     pub fn int() -> Self {
         Self {
             ts: TypeSet::int(),
-            annotated: true,
-        }
-    }
-
-    pub fn int_unannotated() -> Self {
-        Self {
-            ts: TypeSet::int(),
             annotated: false,
         }
     }
@@ -106,13 +99,6 @@ impl TypeSetAnnotated {
     }
 
     pub fn float() -> Self {
-        Self {
-            ts: TypeSet::float(),
-            annotated: true,
-        }
-    }
-
-    pub fn float_unannotated() -> Self {
         Self {
             ts: TypeSet::float(),
             annotated: true,

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -136,7 +136,7 @@ pub fn type_check(src: &str) -> Result<JsValue, JsValue> {
 
 #[wasm_bindgen]
 pub fn run_script(src: &str) -> Result<(), JsValue> {
-    let mut ctx = EvalContext::new();
+    let mut ctx = EvalContext::default();
     wasm_functions(|name, f| ctx.set_fn(name, f));
     let parse_result =
         source(src).map_err(|e| JsValue::from_str(&format!("Parse error: {:?}", e)))?;


### PR DESCRIPTION
# The problem

The parser could not parse a source like this:

```
a[0].s
```

It means "the field `s` of an element at index `0` of an array `a`", but the parser will give up at the array index part and return `a[0]`.

This kind of construct shows up when an access to an element in nested containers. In parser's terms, it is a chained postfix expression.

# The solution

We need to call postfix parser again after an postfix parser was returned, but it is not as easy as it sounds. For example, a single level postfix expression is parsed like a pseudo data structure representation like below.

```
a[0] ->
ArrayIndex("a", 0)
```

If it's nested, the _prefix_ needs to be put inside the outer container, which means the outermost container is not determined until the parser finishes parsing the whole chain of postfixes.

```
a[0].s ->
FieldAccess(ArrayIndex("a", 0), "s")
```

A simple counter-example is the container literals. For example, an array literal is like this:

```
[0] ->
ArrayLiteral(vec![0])
```

And if you put it inside a tuple, it will look like this:

```
([0],) -> 
TupleLiteral(vec![ArrayLiteral(vec![0])])
```

The outer parser matches the outer container that would be produced by the parser. This kind of parsers are easy to write and `nom` have very good support of combinators for them.

One easy solution is to backtrack; you can assume the nested structure of the postfix expression first, try to parse it, retry with another, repeat until succeeds. However, this is very inefficient algorithm, especially when there are many alternatives in the postfix part.

Therefore, we use the state in the parser instead and avoid backtracking as much as possible.

The postfix parsers share this signature:

```rust
type PostfixInput<'src> = (Span<'src>, Expression<'src>, Span<'src>);

pub(crate) fn field_access<'src>(
    (start, prefix, i): &PostfixInput<'src>,
) -> IResult<Span<'src>, Expression<'src>>;
```

The argument tuple contains the state and also the span to parse next source text. The first element `start` is the beginning of the whole postfix expression, the second is the parsed prefix expression so far, and the last is the span pointing the next source text.

Unfortunately, `nom` does not support stateful parsers per se (you could put it inside the parameter, but it would be more complicated), so we need to write down `if let` and return in a manual chain.

```rust
fn postfix<'src>(arg: PostfixInput<'src>) -> IResult<Span<'src>, Expression<'src>> {
    if let Ok(res) = array_index(&arg) {
        return Ok(res);
    }

    if let Ok(res) = tuple_index(&arg) {
        return Ok(res);
    }

    if let Ok(res) = field_access(&arg) {
        return Ok(res);
    }

    if let Ok(res) = cast(&arg) {
        return Ok(res);
    }

    Ok((arg.2, arg.1.clone()))
}
```