### PR TITLE
Make function objects as first class values

### DIFF
--- a/parser/src/bytecode.rs
+++ b/parser/src/bytecode.rs
@@ -23,6 +23,7 @@ use crate::{
 #[derive(Debug, Clone, Copy)]
 #[repr(u8)]
 pub enum OpCode {
+    /// Copy a literal from literal table at index arg0 to stack at arg1.
     LoadLiteral,
     /// Move values between stack elements, from arg0 to arg1.
     Move,

--- a/parser/src/coercion.rs
+++ b/parser/src/coercion.rs
@@ -2,7 +2,7 @@ use std::{cell::RefCell, rc::Rc};
 
 use crate::{
     interpreter::{EvalResult, TypeMap},
-    type_decl::ArraySize,
+    type_decl::{ArraySize, FuncDecl},
     value::{ArrayInt, TupleEntry},
     EvalError, TypeDecl, Value,
 };
@@ -199,13 +199,13 @@ pub fn coerce_type(value: &Value, target: &TypeDecl) -> Result<Value, EvalError>
                 format!("typename {name}"),
             ));
         }
-        TypeDecl::Func(name) => {
+        TypeDecl::Func(FuncDecl { args, ret_ty }) => {
             if let Value::Func(_str) = value {
                 return Ok(value.clone());
             }
             return Err(EvalError::CoerceError(
                 value.to_string(),
-                format!("Func {name}"),
+                format!("fn({args:?}) -> {ret_ty}"),
             ));
         }
     })

--- a/parser/src/coercion.rs
+++ b/parser/src/coercion.rs
@@ -199,11 +199,14 @@ pub fn coerce_type(value: &Value, target: &TypeDecl) -> Result<Value, EvalError>
                 format!("typename {name}"),
             ));
         }
-        TypeDecl::Func => {
+        TypeDecl::Func(name) => {
             if let Value::Func(_str) = value {
                 return Ok(value.clone());
             }
-            return Err(EvalError::CoerceError(value.to_string(), format!("Func")));
+            return Err(EvalError::CoerceError(
+                value.to_string(),
+                format!("Func {name}"),
+            ));
         }
     })
 }

--- a/parser/src/coercion.rs
+++ b/parser/src/coercion.rs
@@ -149,6 +149,7 @@ fn _coerce_var(value: &Value, target: &Value, typedefs: &TypeMap) -> Result<Valu
             };
             Value::Struct(value.clone())
         }
+        Value::Func(str) => Value::Func(str.clone()),
     })
 }
 
@@ -197,6 +198,12 @@ pub fn coerce_type(value: &Value, target: &TypeDecl) -> Result<Value, EvalError>
                 value.to_string(),
                 format!("typename {name}"),
             ));
+        }
+        TypeDecl::Func => {
+            if let Value::Func(_str) = value {
+                return Ok(value.clone());
+            }
+            return Err(EvalError::CoerceError(value.to_string(), format!("Func")));
         }
     })
 }

--- a/parser/src/compiler.rs
+++ b/parser/src/compiler.rs
@@ -43,14 +43,63 @@ impl Default for Target {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct LocalVar {
     name: String,
     stack_idx: usize,
 }
 
+/// A local variable or a global function reference.
+/// For now, we do not have a temporary functions but global ones, so we reference it by a name.
+#[derive(Clone)]
+enum UniversalVar<'src> {
+    Local(LocalVar),
+    Func {
+        name: String,
+        proto: Rc<FnProto>,
+        span: Span<'src>,
+    },
+}
+
+impl<'src> std::fmt::Debug for UniversalVar<'src> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Local(local) => local.fmt(f),
+            Self::Func { name, .. } => write!(f, "<Func {name}>"),
+        }
+    }
+}
+
+impl<'src> UniversalVar<'src> {
+    /// Returns the target stack index if the variable is local, otherwise fails.
+    fn as_stack(&self) -> CompileResult<'src, usize> {
+        match self {
+            Self::Local(local) => Ok(local.stack_idx),
+            Self::Func { span, .. } => Err(CompileError::new(*span, CEK::ExpectStackValue)),
+        }
+    }
+
+    /// Creates a copy of the variable in the target stack and returns its index.
+    /// If it was local it will be moved to the topmost element, otherwise loaded from a literal.
+    /// Note that this function is infallible.
+    fn into_stack(&self, compiler: &mut Compiler<'_, 'src>) -> usize {
+        match self {
+            UniversalVar::Local(local) => {
+                let arg_target = compiler.target_stack.len();
+                compiler.target_stack.push(Target::None);
+                compiler.push_inst(OpCode::Move, local.stack_idx as u8, arg_target as u16);
+                arg_target
+            }
+            UniversalVar::Func { name, .. } => {
+                compiler.target_stack.push(Target::None);
+                compiler.find_or_create_literal(&Value::Func(name.clone()))
+            }
+        }
+    }
+}
+
 struct CompilerEnv<'src> {
-    functions: HashMap<String, FnProto>,
+    functions: HashMap<String, Rc<FnProto>>,
     debug: HashMap<String, FunctionInfo>,
     typedefs: TypeMap<'src>,
 }
@@ -62,7 +111,10 @@ impl<'src> CompilerEnv<'src> {
             functions.insert(name, FnProto::Native(f));
         });
         Self {
-            functions,
+            functions: functions
+                .into_iter()
+                .map(|(k, v)| (k, Rc::new(v)))
+                .collect(),
             debug,
             typedefs: TypeMap::new(),
         }
@@ -168,6 +220,27 @@ impl<'a, 'src> Compiler<'a, 'src> {
                 }
             })
             .ok_or_else(|| CompileError::new(span, CEK::VarNotFound(name.to_string())))
+    }
+
+    fn find_universal(
+        &self,
+        name: &str,
+        span: Span<'src>,
+    ) -> CompileResult<'src, UniversalVar<'src>>
+    where
+        'src: 'a,
+    {
+        if let Ok(local) = self.find_local(name, span) {
+            return Ok(UniversalVar::Local(local.clone()));
+        }
+        if let Some(proto) = self.env.functions.get(name) {
+            return Ok(UniversalVar::Func {
+                name: name.to_string(),
+                proto: proto.clone(),
+                span,
+            });
+        }
+        Err(CompileError::new(span, CEK::VarNotFound(name.to_string())))
     }
 
     fn push_inst(&mut self, op: OpCode, arg0: u8, arg1: u16) -> usize {
@@ -298,7 +371,11 @@ impl<'src, 'ast> CompilerBuilder<'src, 'ast> {
             env.debug.insert("".to_string(), source_map);
         }
 
-        let mut functions = env.functions;
+        let mut functions: HashMap<String, FnProto> = env
+            .functions
+            .into_iter()
+            .map(|(k, v)| (k, Rc::into_inner(v).unwrap()))
+            .collect();
         functions.insert("".to_string(), bytecode);
 
         for (fname, fnproto) in &functions {
@@ -359,7 +436,7 @@ fn retrieve_fn_signatures(stmts: &[Statement], env: &mut CompilerEnv) {
                 let args = args.iter().map(|arg| arg.name.to_string()).collect();
                 let bytecode = FnBytecode::proto(name.to_string(), args);
                 env.functions
-                    .insert(name.to_string(), FnProto::Code(bytecode));
+                    .insert(name.to_string(), Rc::new(FnProto::Code(bytecode)));
                 retrieve_fn_signatures(stmts, env);
             }
             _ => {}
@@ -383,7 +460,7 @@ fn emit_stmts<'src>(
                     .ok_or_else(|| CompileError::new(*var, CEK::LocalsStackUnderflow))?
                     .len();
                 let init_val = if let Some(init_expr) = init {
-                    let stk_var = emit_expr(init_expr, compiler)?;
+                    let stk_var = emit_expr(init_expr, compiler)?.as_stack()?;
                     compiler.target_stack[stk_var] = Target::Local(locals);
                     stk_var
                 } else {
@@ -448,11 +525,14 @@ fn emit_stmts<'src>(
                     a_args,
                     fn_args,
                 )?;
-                compiler.env.functions.insert(name.to_string(), fun);
+                compiler
+                    .env
+                    .functions
+                    .insert(name.to_string(), Rc::new(fun));
                 compiler.env.debug.insert(name.to_string(), debug);
             }
             Statement::Expression { ref ex, semicolon } => {
-                let res = emit_expr(ex, compiler)?;
+                let res = emit_expr(ex, compiler)?.as_stack()?;
                 last_target = if *semicolon { None } else { Some(res) };
             }
             Statement::Loop(stmts) => {
@@ -463,7 +543,7 @@ fn emit_stmts<'src>(
             }
             Statement::While(cond, stmts) => {
                 let inst_loop_start = compiler.bytecode.instructions.len();
-                let stk_cond = emit_expr(cond, compiler)?;
+                let stk_cond = emit_expr(cond, compiler)?.as_stack()?;
                 let inst_break = compiler.push_inst(OpCode::Jf, stk_cond as u8, 0);
                 last_target = emit_stmts(stmts, compiler)?;
                 compiler.push_inst(OpCode::Jmp, 0, inst_loop_start as u16);
@@ -478,8 +558,8 @@ fn emit_stmts<'src>(
                 stmts,
                 ..
             } => {
-                let stk_from = emit_expr(start, compiler)?;
-                let stk_to = emit_expr(end, compiler)?;
+                let stk_from = emit_expr(start, compiler)?.as_stack()?;
+                let stk_to = emit_expr(end, compiler)?.as_stack()?;
                 let local_iter = compiler
                     .locals
                     .last()
@@ -534,7 +614,7 @@ fn emit_stmts<'src>(
 fn emit_expr<'src>(
     expr: &Expression<'src>,
     compiler: &mut Compiler<'_, 'src>,
-) -> CompileResult<'src, usize> {
+) -> CompileResult<'src, UniversalVar<'src>> {
     compiler.start_src_pos(expr.span.into());
     let res = match &expr.expr {
         ExprEnum::NumLiteral(val, _) => Ok(compiler.find_or_create_literal(val)),
@@ -596,21 +676,18 @@ fn emit_expr<'src>(
                 // Copy the elements in a contiguous region of the stack.
                 // It is important to not call emit_expr between those elements, since they can push temporary variables.
                 for arg in &arg_values {
-                    let arg_target = compiler.target_stack.len();
-                    compiler.target_stack.push(Target::None);
-                    compiler.push_inst(OpCode::Move, *arg as u8, arg_target as u16);
+                    arg.into_stack(compiler);
                 }
 
                 compiler.push_inst(OpCode::MakeTuple, arg_values.len() as u8, stk_ret as u16);
                 Ok(stk_ret)
             }
         }
-        ExprEnum::Variable(str) => {
-            let local = compiler.find_local(*str, expr.span)?;
-            Ok(local.stack_idx)
-        }
+        ExprEnum::Variable(str) => Ok(compiler
+            .find_universal(*str, expr.span)?
+            .into_stack(compiler)),
         ExprEnum::Cast(ex, decl) => {
-            let val = emit_expr(ex, compiler)?;
+            let val = emit_expr(ex, compiler)?.into_stack(compiler);
             // Make a copy of the value to avoid overwriting original variable
             let val_copy = compiler.target_stack.len();
             compiler.push_inst(OpCode::Move, val as u8, val_copy as u16);
@@ -623,17 +700,17 @@ fn emit_expr<'src>(
             Ok(val_copy)
         }
         ExprEnum::Not(val) => {
-            let val = emit_expr(val, compiler)?;
+            let val = emit_expr(val, compiler)?.into_stack(compiler);
             compiler.push_inst(OpCode::Not, val as u8, 0);
             Ok(val)
         }
         ExprEnum::BitNot(val) => {
-            let val = emit_expr(val, compiler)?;
+            let val = emit_expr(val, compiler)?.into_stack(compiler);
             compiler.push_inst(OpCode::BitNot, val as u8, 0);
             Ok(val)
         }
         ExprEnum::Neg(val) => {
-            let val = emit_expr(val, compiler)?;
+            let val = emit_expr(val, compiler)?.into_stack(compiler);
             compiler.push_inst(OpCode::Neg, val as u8, 0);
             Ok(val)
         }
@@ -643,7 +720,7 @@ fn emit_expr<'src>(
         ExprEnum::Div(lhs, rhs) => Ok(emit_binary_op(compiler, OpCode::Div, lhs, rhs)?),
         ExprEnum::VarAssign(lhs, rhs) => {
             let lhs_result = emit_lvalue(lhs, compiler)?;
-            let rhs_result = emit_expr(rhs, compiler)?;
+            let rhs_result = emit_expr(rhs, compiler)?.into_stack(compiler);
             match lhs_result {
                 LValue::Variable(name) => {
                     let local_idx = compiler.find_local(&name, expr.span)?.stack_idx;
@@ -679,11 +756,21 @@ fn emit_expr<'src>(
             };
 
             let params = {
-                let fun = compiler.env.functions.get(fname).ok_or_else(|| {
-                    CompileError::new(expr.span, CEK::FnNotFound(fname.to_string()))
-                })?;
+                let fun = compiler.find_universal(fname, fn_expr.span)?;
 
-                fun.args().map(|args| args.to_vec())
+                match fun {
+                    UniversalVar::Func { proto, .. } => proto.args().map(|args| args.to_vec()),
+                    UniversalVar::Local(_local) => {
+                        // let ts = tc_expr_forward(fn_expr, &mut TypeCheckContext::new(None))
+                        //     .map_err(|e| CompileError::new(fn_expr.span, CEK::TypeCheck(e.to_string())))?;
+                        // let ty = ts.determine().ok_or_else(|| CompileError::new(fn_expr.span, CEK::TypeCheck("Indeterminant type".to_string())))?;
+                        // let RetType::Some(TypeDecl::Func(func_ty)) = ty else {
+                        //     return Err(CompileError::new(expr.span, CEK::FnNotFound(fn_expr.span.to_string())));
+                        // };
+                        // Some(func_ty.args.to_vec())
+                        None
+                    }
+                }
             };
 
             // Prepare a buffer for actual arguments. It could be a mix of unnamed and named arguments.
@@ -721,21 +808,29 @@ fn emit_expr<'src>(
                     }
                     if let Some(default_val) = param.init.as_ref() {
                         let default_val = compiler.find_or_create_literal(default_val);
-                        *arg_value = Some(default_val);
+                        *arg_value = Some(UniversalVar::Local(LocalVar {
+                            name: "".to_string(),
+                            stack_idx: default_val,
+                        }));
                     }
                 }
             }
 
-            let stk_fname = compiler.find_or_create_literal(&Value::Str(fname.to_string()));
+            let uv_fname = compiler.find_universal(fname, fn_expr.span)?;
 
-            let Some(_fun) = compiler.env.functions.get(fname) else {
-                return Err(CompileError::new(
-                    expr.span,
-                    CEK::FnNotFound(fname.to_string()),
-                ));
-            };
+            if let UniversalVar::Func { name, .. } = &uv_fname {
+                let Some(_fun) = compiler.env.functions.get(name) else {
+                    return Err(CompileError::new(
+                        expr.span,
+                        CEK::FnNotFound(name.to_string()),
+                    ));
+                };
+                dbg_println!("FnProto found for: {fname}, args: {:?}", _fun.args());
+            } else {
+                dbg_println!("FnProto is behind a local var: {fname}");
+            }
 
-            dbg_println!("FnProto found for: {fname}, args: {:?}", _fun.args());
+            let stk_fname = uv_fname.into_stack(compiler);
 
             // If a named argument is duplicate, you would have a hole in actual args.
             // Until we have the default parameter value, it would be a compile error.
@@ -746,9 +841,7 @@ fn emit_expr<'src>(
 
             // Align arguments to the stack to prepare a call.
             for arg in &arg_values {
-                let arg_target = compiler.target_stack.len();
-                compiler.target_stack.push(Target::None);
-                compiler.push_inst(OpCode::Move, *arg as u8, arg_target as u16);
+                arg.into_stack(compiler);
             }
 
             compiler.push_inst(OpCode::Call, arg_values.len() as u8, stk_fname as u16);
@@ -756,10 +849,10 @@ fn emit_expr<'src>(
             Ok(stk_fname)
         }
         ExprEnum::ArrIndex(ex, args) => {
-            let stk_ex = emit_expr(ex, compiler)?;
+            let stk_ex = emit_expr(ex, compiler)?.into_stack(compiler);
             let args = args
                 .iter()
-                .map(|v| emit_expr(v, compiler))
+                .map(|v| emit_expr(v, compiler).map(|uv| uv.into_stack(compiler)))
                 .collect::<Result<Vec<_>, _>>()?;
             let arg = args[0];
             let arg = if matches!(compiler.target_stack[arg], Target::Local(_)) {
@@ -775,7 +868,7 @@ fn emit_expr<'src>(
             Ok(arg)
         }
         ExprEnum::TupleIndex(ex, index) => {
-            let stk_ex = emit_expr(ex, compiler)?;
+            let stk_ex = emit_expr(ex, compiler)?.into_stack(compiler);
             let stk_idx = compiler.find_or_create_literal(&Value::I64(*index as i64));
             let stk_idx_copy = compiler.target_stack.len();
             compiler.target_stack.push(Target::None);
@@ -804,7 +897,7 @@ fn emit_expr<'src>(
                     CompileError::new(prefix.span, CEK::FieldNotFound(postfix.to_string()))
                 })?;
 
-            let stk_ex = emit_expr(prefix, compiler)?;
+            let stk_ex = emit_expr(prefix, compiler)?.into_stack(compiler);
             let stk_idx = compiler.find_or_create_literal(&Value::I64(idx as i64));
             let stk_idx_copy = compiler.target_stack.len();
             compiler.target_stack.push(Target::None);
@@ -830,7 +923,7 @@ fn emit_expr<'src>(
         ExprEnum::And(lhs, rhs) => Ok(emit_binary_op(compiler, OpCode::And, lhs, rhs)?),
         ExprEnum::Or(lhs, rhs) => Ok(emit_binary_op(compiler, OpCode::Or, lhs, rhs)?),
         ExprEnum::Conditional(cond, true_branch, false_branch) => {
-            let cond = emit_expr(cond, compiler)?;
+            let cond = emit_expr(cond, compiler)?.into_stack(compiler);
             let cond_inst_idx = compiler.bytecode.instructions.len();
             compiler.push_inst(OpCode::Jf, cond as u8, 0);
             let true_branch = emit_stmts(true_branch, compiler)?;
@@ -898,9 +991,7 @@ fn emit_expr<'src>(
             // Copy the elements in a contiguous region of the stack.
             // It is important to not call emit_expr between those elements, since they can push temporary variables.
             for arg in &arg_values {
-                let arg_target = compiler.target_stack.len();
-                compiler.target_stack.push(Target::None);
-                compiler.push_inst(OpCode::Move, *arg as u8, arg_target as u16);
+                arg.into_stack(compiler);
             }
 
             compiler.push_inst(OpCode::MakeStruct, arg_values.len() as u8, stk_ret as u16);
@@ -908,7 +999,12 @@ fn emit_expr<'src>(
         }
     };
     compiler.end_src_pos(expr.span.into());
-    res
+    res.map(move |res| {
+        UniversalVar::Local(LocalVar {
+            name: "".to_string(),
+            stack_idx: res,
+        })
+    })
 }
 
 fn emit_binary_op<'src>(
@@ -917,8 +1013,8 @@ fn emit_binary_op<'src>(
     lhs: &Expression<'src>,
     rhs: &Expression<'src>,
 ) -> CompileResult<'src, usize> {
-    let lhs = emit_expr(&lhs, compiler)?;
-    let rhs = emit_expr(&rhs, compiler)?;
+    let lhs = emit_expr(&lhs, compiler)?.as_stack()?;
+    let rhs = emit_expr(&rhs, compiler)?.as_stack()?;
     let lhs = if matches!(compiler.target_stack[lhs], Target::Local(_)) {
         // We move the local variable to another slot because our instructions are destructive
         let top = compiler.target_stack.len();

--- a/parser/src/compiler/error.rs
+++ b/parser/src/compiler/error.rs
@@ -15,8 +15,10 @@ pub enum CompileErrorKind {
     NonLValue(String),
     TypeNameNotFound(String),
     FieldNotFound(String),
+    ExpectStackValue,
     FromUtf8Error(std::string::FromUtf8Error),
     IoError(std::io::Error),
+    TypeCheck(String),
 }
 
 #[derive(Debug)]
@@ -43,7 +45,7 @@ impl std::fmt::Display for CompileErrorKind {
             Self::BreakInArrayLiteral => write!(f, "Break in array literal not supported"),
             Self::DisallowedBreak => write!(f, "Break in function default arg is not allowed"),
             Self::EvalError(e) => write!(f, "Evaluation error: {e}"),
-            Self::VarNotFound(name) => write!(f, "Variable {name} not found in scope"),
+            Self::VarNotFound(name) => write!(f, "Variable {name} not found during compiling"),
             Self::FnNotFound(name) => write!(f, "Function {name} is not defined"),
             Self::InsufficientNamedArgs => {
                 write!(f, "Named arguments does not cover all required args")
@@ -57,8 +59,10 @@ impl std::fmt::Display for CompileErrorKind {
             ),
             Self::TypeNameNotFound(name) => write!(f, "Struct {name} is not defined"),
             Self::FieldNotFound(name) => write!(f, "Field {name} is not defined"),
+            Self::ExpectStackValue => write!(f, "Expect a stack value"),
             Self::FromUtf8Error(e) => e.fmt(f),
             Self::IoError(e) => e.fmt(f),
+            Self::TypeCheck(e) => write!(f, "Type check error: {e}"),
         }
     }
 }

--- a/parser/src/compiler/lvalue.rs
+++ b/parser/src/compiler/lvalue.rs
@@ -38,7 +38,7 @@ pub(super) fn emit_lvalue<'src, 'env, 'c>(
         )),
         ExprEnum::VarAssign(ex, _) => emit_lvalue(ex, compiler),
         ExprEnum::ArrIndex(ex, idx) => {
-            let idx = emit_expr(&idx[0], compiler)?;
+            let idx = emit_expr(&idx[0], compiler)?.as_stack()?;
             let arr = emit_lvalue(ex, compiler)?;
             match arr {
                 LValue::Variable(name) => Ok(LValue::ArrayRef(

--- a/parser/src/eval_error.rs
+++ b/parser/src/eval_error.rs
@@ -44,6 +44,7 @@ pub enum EvalError {
     NoFieldFound(String),
     TypeCheck(String),
     ExpectStruct(TypeDecl),
+    ExpectFn(String),
 }
 
 impl std::convert::From<ValueError> for EvalError {
@@ -126,6 +127,7 @@ impl std::fmt::Display for EvalError {
             Self::NoFieldFound(name) => write!(f, "Field {name} not found"),
             Self::TypeCheck(name) => write!(f, "Type check error: {name}"),
             Self::ExpectStruct(ty) => write!(f, "Expect a struct, but got a {ty}"),
+            Self::ExpectFn(ty) => write!(f, "Expect a function, but got a {ty}"),
         }
     }
 }

--- a/parser/src/format_ast.rs
+++ b/parser/src/format_ast.rs
@@ -30,7 +30,8 @@ pub fn format_expr(
             Ok(())
         }
         ExprEnum::FnInvoke(fname, args) => {
-            write!(f, "{fname}(")?;
+            format_expr(fname, level, f)?;
+            write!(f, "(")?;
             for (i, arg) in args.iter().enumerate() {
                 format_expr(&arg.expr, level, f)?;
                 if i != args.len() - 1 {

--- a/parser/src/interpreter/test.rs
+++ b/parser/src/interpreter/test.rs
@@ -141,7 +141,10 @@ fn fn_invoke_test() {
         vec![Statement::Expression {
             ex: Expression::new(
                 FnInvoke(
-                    "f",
+                    Box::new(Expression::new(
+                        ExprEnum::Variable("f"),
+                        span.subslice(0, 1)
+                    )),
                     vec![FnArg {
                         name: None,
                         expr: *bnl(Value::I64(1), span.subslice(2, 1))
@@ -1061,7 +1064,13 @@ fn for_test() {
             start: nl(Value::I64(0), span.subslice(10, 1)),
             end: nl(Value::I64(10), span.subslice(13, 2)),
             stmts: vec![expr_semi(Expression::new(
-                FnInvoke("print", vec![FnArg::new(*var_r(span.subslice(24, 1)))],),
+                FnInvoke(
+                    Box::new(Expression::new(
+                        ExprEnum::Variable("print"),
+                        span.subslice(18, 5)
+                    )),
+                    vec![FnArg::new(*var_r(span.subslice(24, 1)))],
+                ),
                 span.subslice(18, 8)
             ))]
         }]

--- a/parser/src/interpreter/test.rs
+++ b/parser/src/interpreter/test.rs
@@ -125,7 +125,13 @@ fn fn_invoke_test() {
     assert_eq!(
         source(span).finish().unwrap().1,
         vec![Statement::Expression {
-            ex: Expression::new(FnInvoke("f", vec![]), span.subslice(0, 3)),
+            ex: Expression::new(
+                FnInvoke(
+                    Box::new(Expression::new(Variable("f"), span.subslice(0, 1))),
+                    vec![]
+                ),
+                span.subslice(0, 3)
+            ),
             semicolon: true
         }]
     );

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -82,6 +82,7 @@ impl<'a> ArgDecl<'a> {
         ArgDeclOwned {
             name: self.name.to_string(),
             ty: self.ty.clone(),
+            init: self.init.is_some(),
         }
     }
 }
@@ -322,6 +323,7 @@ fn fn_type(i: Span) -> IResult<Span, TypeDecl> {
                 .map(|arg| ArgDeclOwned {
                     name: arg.name.to_string(),
                     ty: arg.ty,
+                    init: false,
                 })
                 .collect(),
             ret_ty: Box::new(ret_ty.unwrap_or(RetType::Some(TypeDecl::Any))),

--- a/parser/src/parser/test.rs
+++ b/parser/src/parser/test.rs
@@ -549,7 +549,10 @@ fn test_bit_or_arg() {
         full_expression(span).finish().unwrap().1,
         Expression::new(
             ExprEnum::FnInvoke(
-                "a",
+                Box::new(Expression::new(
+                    ExprEnum::Variable("a"),
+                    span.subslice(0, 1)
+                )),
                 vec![FnArg::new(Expression::new(
                     ExprEnum::BitOr(
                         Box::new(Expression::new(int(1), span.subslice(2, 1))),
@@ -972,7 +975,10 @@ fn test_void_fn() {
             ret_type: RetType::Void,
             stmts: Rc::new(vec![expr_nosemi(Expression::new(
                 FnInvoke(
-                    "print",
+                    Box::new(Expression::new(
+                        ExprEnum::Variable("print"),
+                        span.subslice(28, 5)
+                    )),
                     vec![FnArg::new(Expression::new(
                         ExprEnum::StrLiteral("Hello".to_string()),
                         span.subslice(34, 7)
@@ -992,7 +998,10 @@ fn test_fn_call() {
         Statement::Expression {
             ex: Expression::new(
                 ExprEnum::FnInvoke(
-                    "a",
+                    Box::new(Expression::new(
+                        ExprEnum::Variable("a"),
+                        span.subslice(0, 1)
+                    )),
                     vec![FnArg::new(Expression::new(int(0), span.subslice(2, 1)))]
                 ),
                 span

--- a/parser/src/type_decl.rs
+++ b/parser/src/type_decl.rs
@@ -22,6 +22,7 @@ pub enum TypeDecl {
     Array(Box<TypeDecl>, ArraySize),
     Tuple(Vec<TypeDecl>),
     TypeName(String),
+    Func,
 }
 
 impl TypeDecl {
@@ -40,6 +41,7 @@ impl TypeDecl {
                     .collect(),
             ),
             Value::Struct(a) => Self::TypeName(a.borrow().name.clone()),
+            Value::Func(_) => Self::Func,
         }
     }
 
@@ -65,6 +67,7 @@ impl TypeDecl {
                 return Ok(());
             }
             Self::TypeName(_) => todo!(),
+            Self::Func => FUNC_TAG,
         };
         writer.write_all(&tag.to_le_bytes())?;
         Ok(())
@@ -125,6 +128,7 @@ impl std::fmt::Display for TypeDecl {
                 })
             )?,
             Self::TypeName(name) => write!(f, "{name}")?,
+            Self::Func => write!(f, "fn()")?,
         }
         Ok(())
     }

--- a/parser/src/type_decl.rs
+++ b/parser/src/type_decl.rs
@@ -46,14 +46,7 @@ impl TypeDecl {
                 |_| Self::Any,
                 |func| {
                     Self::Func(FuncDecl {
-                        args: func
-                            .args()
-                            .iter()
-                            .map(|arg| ArgDeclOwned {
-                                name: arg.name.to_string(),
-                                ty: arg.ty.clone(),
-                            })
-                            .collect(),
+                        args: func.args().iter().map(|arg| arg.to_deep_owned()).collect(),
                         ret_ty: Box::new(func.ret_ty()),
                     })
                 },
@@ -159,6 +152,9 @@ impl std::fmt::Display for TypeDecl {
 pub struct ArgDeclOwned {
     pub name: String,
     pub ty: TypeDecl,
+    /// Unlike `ArgDecl`, we do not contain the expression for the initializer.
+    /// Instead, we only note that the initializer exists, and its type should match `ty`.
+    pub init: bool,
 }
 
 impl std::fmt::Display for ArgDeclOwned {

--- a/parser/src/type_decl.rs
+++ b/parser/src/type_decl.rs
@@ -22,7 +22,7 @@ pub enum TypeDecl {
     Array(Box<TypeDecl>, ArraySize),
     Tuple(Vec<TypeDecl>),
     TypeName(String),
-    Func,
+    Func(String),
 }
 
 impl TypeDecl {
@@ -41,7 +41,7 @@ impl TypeDecl {
                     .collect(),
             ),
             Value::Struct(a) => Self::TypeName(a.borrow().name.clone()),
-            Value::Func(_) => Self::Func,
+            Value::Func(name) => Self::Func(name.clone()),
         }
     }
 
@@ -67,7 +67,7 @@ impl TypeDecl {
                 return Ok(());
             }
             Self::TypeName(_) => todo!(),
-            Self::Func => FUNC_TAG,
+            Self::Func(_) => FUNC_TAG,
         };
         writer.write_all(&tag.to_le_bytes())?;
         Ok(())
@@ -128,7 +128,7 @@ impl std::fmt::Display for TypeDecl {
                 })
             )?,
             Self::TypeName(name) => write!(f, "{name}")?,
-            Self::Func => write!(f, "fn()")?,
+            Self::Func(name) => write!(f, "fn {name}()")?,
         }
         Ok(())
     }

--- a/parser/src/type_infer.rs
+++ b/parser/src/type_infer.rs
@@ -7,10 +7,10 @@ use std::{collections::HashMap, fmt::Display, marker::PhantomData, rc::Rc};
 
 use crate::{
     format_ast::{format_expr, format_stmt},
-    interpreter::{std_functions, FuncCode, RetType, TypeMapRc},
+    interpreter::{std_functions, RetType, TypeMapRc},
     parser::{ExprEnum, Expression, Statement, StructDecl},
     type_decl::{ArraySize, FuncDecl, TypeDecl},
-    type_set::{TypeSet, TypeSetFlags},
+    type_set::TypeSet,
     FuncDef, Span,
 };
 

--- a/parser/src/type_infer.rs
+++ b/parser/src/type_infer.rs
@@ -377,13 +377,22 @@ where
                 }
             }
 
+            // Assign default values if they are not assigned by invocator
+            for (arg, fn_arg) in ty_args.iter_mut().zip(fn_args.iter()) {
+                if arg.is_some() {
+                    continue;
+                }
+                if fn_arg.init {
+                    *arg = Some(TypeSet::from(fn_arg.ty.clone()));
+                }
+            }
+
             for (ty_arg, decl) in ty_args.iter().zip(fn_args.iter()) {
                 let ty_arg = ty_arg.as_ref().ok_or_else(|| {
                     TypeCheckError::unassigned_arg(&decl.name, e.span, ctx.source_file)
                 })?;
                 tc_coerce_type(&ty_arg, &decl.ty, e.span, ctx)?;
             }
-
             match &*func.ret_ty {
                 RetType::Void => TypeSet::none(),
                 RetType::Some(ty) => ty.into(),

--- a/parser/src/type_set.rs
+++ b/parser/src/type_set.rs
@@ -1,6 +1,10 @@
 use std::collections::HashSet;
 
-use crate::{interpreter::RetType, type_decl::ArraySize, TypeDecl};
+use crate::{
+    interpreter::RetType,
+    type_decl::{ArraySize, FuncDecl},
+    TypeDecl,
+};
 
 /// TypeSet with a flag whether it was annotated in the original source code.
 /// It can keep track of existence of type annotation even after type inference
@@ -63,7 +67,7 @@ pub struct TypeSetFlags {
     pub array: Option<(Box<TypeSet>, ArraySize)>,
     pub tuple: Option<Vec<TypeSet>>,
     pub type_name: Vec<String>,
-    pub func: Option<String>,
+    pub func: Option<FuncDecl>,
 }
 
 impl TypeSetAnnotated {
@@ -122,9 +126,9 @@ impl TypeSetAnnotated {
         }
     }
 
-    pub fn func(name: String) -> Self {
+    pub fn func(func: FuncDecl) -> Self {
         Self {
-            ts: TypeSet::func(name),
+            ts: TypeSet::func(func),
             annotated: true,
         }
     }
@@ -189,9 +193,9 @@ impl TypeSet {
         })
     }
 
-    pub fn func(name: String) -> Self {
+    pub fn func(func: FuncDecl) -> Self {
         Self::Set(TypeSetFlags {
-            func: Some(name),
+            func: Some(func),
             ..TypeSetFlags::default()
         })
     }
@@ -205,6 +209,10 @@ impl TypeSet {
 
     pub fn all() -> Self {
         Self::Any
+    }
+
+    pub fn none() -> Self {
+        Self::Set(TypeSetFlags::default())
     }
 
     pub fn is_none(&self) -> bool {
@@ -468,8 +476,8 @@ impl From<&TypeDecl> for TypeSet {
             TypeDecl::TypeName(name) => {
                 return TypeSet::type_name(name.clone());
             }
-            TypeDecl::Func(name) => {
-                return TypeSet::func(name.clone());
+            TypeDecl::Func(func) => {
+                return TypeSet::func(func.clone());
             }
         }
         Self::Set(ret)

--- a/parser/src/type_set.rs
+++ b/parser/src/type_set.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use crate::{
     interpreter::RetType,
     type_decl::{ArraySize, FuncDecl},
@@ -44,13 +42,6 @@ impl TypeSet {
     ) -> Option<T> {
         match self {
             Self::Any => None,
-            Self::Set(set) => f(set),
-        }
-    }
-
-    pub fn is_any_or<'a>(&'a self, f: impl Fn(&'a TypeSetFlags) -> bool) -> bool {
-        match self {
-            Self::Any => true,
             Self::Set(set) => f(set),
         }
     }
@@ -123,13 +114,6 @@ impl TypeSetAnnotated {
         Self {
             ts: TypeSet::Any,
             annotated: false,
-        }
-    }
-
-    pub fn func(func: FuncDecl) -> Self {
-        Self {
-            ts: TypeSet::func(func),
-            annotated: true,
         }
     }
 }
@@ -580,6 +564,10 @@ impl std::fmt::Display for TypeSetFlags {
 
         for tn in &self.type_name {
             write_ty(true, tn)?;
+        }
+
+        if let Some(func) = &self.func {
+            write_ty(true, &func.to_string())?;
         }
 
         if !written {

--- a/parser/src/type_tags.rs
+++ b/parser/src/type_tags.rs
@@ -6,3 +6,4 @@ pub(crate) const STR_TAG: u8 = 4;
 pub(crate) const ARRAY_TAG: u8 = 5;
 pub(crate) const TUPLE_TAG: u8 = 6;
 pub(crate) const STRUCT_TAG: u8 = 7;
+pub(crate) const FUNC_TAG: u8 = 4;

--- a/parser/src/value.rs
+++ b/parser/src/value.rs
@@ -5,8 +5,8 @@ use std::{
 };
 
 use crate::{
-    interpreter::{EGetExt, EvalResult},
-    type_decl::{ArraySize, TypeDecl},
+    interpreter::{EGetExt, EvalResult, RetType},
+    type_decl::{ArraySize, FuncDecl, TypeDecl},
     type_tags::*,
     EvalError, ReadError,
 };
@@ -373,8 +373,8 @@ impl std::convert::TryFrom<&Value> for usize {
                     TypeDecl::I64,
                 ))
             }
-            Value::Func(name) => Err(ValueError::Invalid(
-                TypeDecl::Func(name.clone()),
+            Value::Func(_name) => Err(ValueError::Invalid(
+                TypeDecl::Func(FuncDecl::default()),
                 TypeDecl::I64,
             )),
         }

--- a/parser/src/value.rs
+++ b/parser/src/value.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use crate::{
-    interpreter::{EGetExt, EvalResult, RetType},
+    interpreter::{EGetExt, EvalResult},
     type_decl::{ArraySize, FuncDecl, TypeDecl},
     type_tags::*,
     EvalError, ReadError,

--- a/parser/src/value.rs
+++ b/parser/src/value.rs
@@ -373,7 +373,10 @@ impl std::convert::TryFrom<&Value> for usize {
                     TypeDecl::I64,
                 ))
             }
-            Value::Func(_) => Err(ValueError::Invalid(TypeDecl::Func, TypeDecl::I64)),
+            Value::Func(name) => Err(ValueError::Invalid(
+                TypeDecl::Func(name.clone()),
+                TypeDecl::I64,
+            )),
         }
     }
 }

--- a/parser/src/vm.rs
+++ b/parser/src/vm.rs
@@ -443,7 +443,7 @@ impl<'a> Vm<'a> {
             }
             OpCode::Call => {
                 let arg_name = self.get(inst.arg1);
-                let arg_name = if let Value::Str(s) = arg_name {
+                let arg_name = if let Value::Str(s) | Value::Func(s) = arg_name {
                     s
                 } else {
                     return Err(EvalError::NonNameFnRef(format!("{arg_name:?}")));

--- a/parser/src/vm.rs
+++ b/parser/src/vm.rs
@@ -226,14 +226,7 @@ fn interpret_fn(
     );
     dbg_println!("size callInfo: {}", std::mem::size_of::<CallInfo>());
     dbg_println!("literals: {:?}", bytecode.literals);
-    #[cfg(debug_assertions)]
-    {
-        let mut buf = vec![0u8; 0];
-        bytecode.disasm(&mut buf).unwrap();
-        if let Ok(s) = String::from_utf8(buf) {
-            dbg_println!("instructions: {}", s);
-        }
-    }
+
     let mut vm = Vm::new(bytecode, functions);
     let value = loop {
         if let Some(res) = vm.next_inst()? {

--- a/scripts/fn_callback.dragon
+++ b/scripts/fn_callback.dragon
@@ -1,0 +1,11 @@
+
+/* add two values */
+fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+fn call_arg(f: fn) -> i32 {
+    f(123, 456)
+}
+
+print(call_arg(add));

--- a/scripts/fn_callback.dragon
+++ b/scripts/fn_callback.dragon
@@ -1,11 +1,15 @@
 
-/* add two values */
 fn add(a: i32, b: i32) -> i32 {
     a + b
 }
 
-fn call_arg(f: fn) -> i32 {
+fn sub(a: i32, b: i32) -> i32 {
+    a - b
+}
+
+fn call_arg(f: fn(i32, i32) -> i32) -> i32 {
     f(123, 456)
 }
 
 print(call_arg(add));
+print(call_arg(sub));

--- a/scripts/fn_default.dragon
+++ b/scripts/fn_default.dragon
@@ -1,7 +1,7 @@
 
 /* add two values */
-fn add(a: i32 = 123, b: i32 = 456) {
-    a + b;
+fn add(a: i32 = 123, b: i32 = 456) -> i32 {
+    a + b
 }
 
 // print(add(123, 456));

--- a/scripts/fn_obj.dragon
+++ b/scripts/fn_obj.dragon
@@ -4,5 +4,5 @@ fn add(a: i32, b: i32) -> i32 {
     a + b
 }
 
-var alias = add;
+var alias: fn(i32, i32) -> i32 = add;
 print(alias(123, 456));

--- a/scripts/fn_obj.dragon
+++ b/scripts/fn_obj.dragon
@@ -1,0 +1,10 @@
+
+/* add two values */
+fn add(a: i32, b: i32) {
+    a + b;
+}
+
+var alias = add;
+print(alias(123, 456));
+
+var alias2 = alias;

--- a/scripts/fn_obj.dragon
+++ b/scripts/fn_obj.dragon
@@ -1,10 +1,8 @@
 
 /* add two values */
-fn add(a: i32, b: i32) {
-    a + b;
+fn add(a: i32, b: i32) -> i32 {
+    a + b
 }
 
 var alias = add;
 print(alias(123, 456));
-
-var alias2 = alias;

--- a/scripts/fn_obj_ret.dragon
+++ b/scripts/fn_obj_ret.dragon
@@ -1,0 +1,11 @@
+
+/* add two values */
+fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+fn return_add() -> fn(i32, i32) -> i32 {
+    add
+}
+
+print(return_add()(123, 456));

--- a/wasm/js/main.js
+++ b/wasm/js/main.js
@@ -75,6 +75,7 @@ const samples = document.getElementById("samples");
     "pipe.dragon",
     "cmp.dragon",
     "struct.dragon", "struct_infer.dragon", "struct_nested.dragon",
+    "fn_obj.dragon", "fn_obj_ret.dragon", "fn_callback.dragon",
 ]
     .forEach(fileName => {
     const link = document.createElement("a");

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -57,6 +57,7 @@ fn s_puts(vals: &[Value]) -> Result<Value, EvalError> {
                         .collect::<Vec<_>>(),
                 ),
                 Value::Struct(val) => puts_inner(val.borrow().fields()),
+                Value::Func(f) => wasm_print(&format!("{}()", f)),
             }
         }
     }


### PR DESCRIPTION
Now we can assign a function to a variable

```
fn add(a: i32, b: i32) -> i32 {
  a + b
}

var alias = add;
alias(123, 456);
```

Or pass as an argument to a function

```
fn call_f(f: fn(i32, i32) -> i32) -> i32 {
  f(123, 456)
}

call_f(add);
```

Or return from a function

```
fn build_adder() -> fn(i32, i32) -> i32 {
  add
}

build_adder()(123, 456);
```

It requires a lot of rework in parser and value type variants.

Note that we still don't support closures.